### PR TITLE
(entity, data) 관련 수정, 이메일 인증 구현

### DIFF
--- a/simpleBoard02/server-b-user/build.gradle
+++ b/simpleBoard02/server-b-user/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     testImplementation 'org.testcontainers:testcontainers:1.19.3'
+    testImplementation 'org.testcontainers:junit-jupiter:1.19.3'
     testImplementation 'com.redis.testcontainers:testcontainers-redis:1.6.4'
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/simpleBoard02/server-b-user/build.gradle
+++ b/simpleBoard02/server-b-user/build.gradle
@@ -9,4 +9,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0"
 
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 }

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/advice/GlobalAdvice.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/advice/GlobalAdvice.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.stream.StreamSupport;
 
 import static kim.zhyun.serveruser.data.message.ExceptionMessage.REQUIRED_REQUEST_BODY;
-import static kim.zhyun.serveruser.data.message.ResponseMessage.VALID_EXCEPTION;
+import static kim.zhyun.serveruser.data.message.ExceptionMessage.VALID_EXCEPTION;
 
 @RestControllerAdvice
 public class GlobalAdvice extends ResponseEntityExceptionHandler {

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/advice/GlobalAdvice.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/advice/GlobalAdvice.java
@@ -29,7 +29,7 @@ public class GlobalAdvice extends ResponseEntityExceptionHandler {
         return ResponseEntity
                 .badRequest().body(ApiResponse.<List<ValidExceptionResponse>>builder()
                         .status(false)
-                        .message(e.getExceptionType()).build());
+                        .message(e.getExceptionMessage()).build());
     }
     
     @ExceptionHandler(ConstraintViolationException.class)

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/advice/GlobalAdvice.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/advice/GlobalAdvice.java
@@ -24,6 +24,14 @@ import static kim.zhyun.serveruser.data.message.ResponseMessage.VALID_EXCEPTION;
 @RestControllerAdvice
 public class GlobalAdvice extends ResponseEntityExceptionHandler {
     
+    @ExceptionHandler(MailAuthException.class)
+    public ResponseEntity<Object> mailException(MailAuthException e) {
+        return ResponseEntity
+                .badRequest().body(ApiResponse.<List<ValidExceptionResponse>>builder()
+                        .status(false)
+                        .message(e.getExceptionType()).build());
+    }
+    
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<Object> constraintViolationException(ConstraintViolationException e) {
         List<ValidExceptionResponse> errorList = new ArrayList<>();

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/advice/GlobalAdvice.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/advice/GlobalAdvice.java
@@ -19,7 +19,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.StreamSupport;
 
-import static kim.zhyun.serveruser.data.type.ResponseMessage.VALID_EXCEPTION;
+import static kim.zhyun.serveruser.data.message.ResponseMessage.VALID_EXCEPTION;
 
 @RestControllerAdvice
 public class GlobalAdvice extends ResponseEntityExceptionHandler {

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/advice/GlobalAdvice.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/advice/GlobalAdvice.java
@@ -7,6 +7,7 @@ import kim.zhyun.serveruser.data.ValidExceptionResponse;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -19,6 +20,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.StreamSupport;
 
+import static kim.zhyun.serveruser.data.message.ExceptionMessage.REQUIRED_REQUEST_BODY;
 import static kim.zhyun.serveruser.data.message.ResponseMessage.VALID_EXCEPTION;
 
 @RestControllerAdvice
@@ -57,6 +59,14 @@ public class GlobalAdvice extends ResponseEntityExceptionHandler {
                         .status(false)
                         .message(VALID_EXCEPTION)
                         .result(errorList).build());
+    }
+    
+    @Override
+    protected ResponseEntity<Object> handleHttpMessageNotReadable(HttpMessageNotReadableException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        return ResponseEntity
+                .badRequest().body(ApiResponse.<List<ValidExceptionResponse>>builder()
+                        .status(false)
+                        .message(REQUIRED_REQUEST_BODY).build());
     }
     
     @Override

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/advice/MailAuthException.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/advice/MailAuthException.java
@@ -1,0 +1,15 @@
+package kim.zhyun.serveruser.advice;
+
+import kim.zhyun.serveruser.data.type.ExceptionType;
+import lombok.Getter;
+
+@Getter
+public class MailAuthException extends RuntimeException {
+    private final ExceptionType exceptionType;
+    
+    public MailAuthException(ExceptionType exceptionType) {
+        super(exceptionType.getDescription());
+        this.exceptionType = exceptionType;
+    }
+    
+}

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/advice/MailAuthException.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/advice/MailAuthException.java
@@ -1,14 +1,13 @@
 package kim.zhyun.serveruser.advice;
 
-import kim.zhyun.serveruser.data.message.ExceptionMessage;
 import lombok.Getter;
 
 @Getter
 public class MailAuthException extends RuntimeException {
-    private final ExceptionMessage exceptionMessage;
+    private final String exceptionMessage;
     
-    public MailAuthException(ExceptionMessage exceptionMessage) {
-        super(exceptionMessage.getMessage());
+    public MailAuthException(String exceptionMessage) {
+        super(exceptionMessage);
         this.exceptionMessage = exceptionMessage;
     }
     

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/advice/MailAuthException.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/advice/MailAuthException.java
@@ -1,15 +1,15 @@
 package kim.zhyun.serveruser.advice;
 
-import kim.zhyun.serveruser.data.type.ExceptionType;
+import kim.zhyun.serveruser.data.message.ExceptionMessage;
 import lombok.Getter;
 
 @Getter
 public class MailAuthException extends RuntimeException {
-    private final ExceptionType exceptionType;
+    private final ExceptionMessage exceptionMessage;
     
-    public MailAuthException(ExceptionType exceptionType) {
-        super(exceptionType.getDescription());
-        this.exceptionType = exceptionType;
+    public MailAuthException(ExceptionMessage exceptionMessage) {
+        super(exceptionMessage.getDescription());
+        this.exceptionMessage = exceptionMessage;
     }
     
 }

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/advice/MailAuthException.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/advice/MailAuthException.java
@@ -8,7 +8,7 @@ public class MailAuthException extends RuntimeException {
     private final ExceptionMessage exceptionMessage;
     
     public MailAuthException(ExceptionMessage exceptionMessage) {
-        super(exceptionMessage.getDescription());
+        super(exceptionMessage.getMessage());
         this.exceptionMessage = exceptionMessage;
     }
     

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/advice/NotFoundSessionException.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/advice/NotFoundSessionException.java
@@ -1,14 +1,13 @@
 package kim.zhyun.serveruser.advice;
 
-import kim.zhyun.serveruser.data.message.ExceptionMessage;
 import lombok.Getter;
 
 @Getter
 public class NotFoundSessionException extends RuntimeException {
-    private final ExceptionMessage exceptionMessage;
+    private final String exceptionMessage;
     
-    public NotFoundSessionException(ExceptionMessage exceptionMessage) {
-        super(exceptionMessage.getMessage());
+    public NotFoundSessionException(String exceptionMessage) {
+        super(exceptionMessage);
         this.exceptionMessage = exceptionMessage;
     }
     

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/advice/NotFoundSessionException.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/advice/NotFoundSessionException.java
@@ -8,7 +8,7 @@ public class NotFoundSessionException extends RuntimeException {
     private final ExceptionMessage exceptionMessage;
     
     public NotFoundSessionException(ExceptionMessage exceptionMessage) {
-        super(exceptionMessage.getDescription());
+        super(exceptionMessage.getMessage());
         this.exceptionMessage = exceptionMessage;
     }
     

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/advice/NotFoundSessionException.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/advice/NotFoundSessionException.java
@@ -1,15 +1,15 @@
 package kim.zhyun.serveruser.advice;
 
-import kim.zhyun.serveruser.data.type.ExceptionType;
+import kim.zhyun.serveruser.data.message.ExceptionMessage;
 import lombok.Getter;
 
 @Getter
 public class NotFoundSessionException extends RuntimeException {
-    private final ExceptionType exceptionType;
+    private final ExceptionMessage exceptionMessage;
     
-    public NotFoundSessionException(ExceptionType exceptionType) {
-        super(exceptionType.getDescription());
-        this.exceptionType = exceptionType;
+    public NotFoundSessionException(ExceptionMessage exceptionMessage) {
+        super(exceptionMessage.getDescription());
+        this.exceptionMessage = exceptionMessage;
     }
     
 }

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/config/MailConfig.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/config/MailConfig.java
@@ -1,0 +1,50 @@
+package kim.zhyun.serveruser.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class MailConfig {
+    
+    @Value("${spring.mail.protocol}")               private String protocol;
+    @Value("${spring.mail.host}")                   private String host;
+    @Value("${spring.mail.port}")                   private int port;
+    @Value("${spring.mail.username}")               private String id;
+    @Value("${spring.mail.password}")               private String password;
+    @Value("${spring.mail.default-encoding}")       private String encoding;
+    
+    @Value("${spring.mail.properties.debug}")                       private String debug;
+    @Value("${spring.mail.properties.mail.smtp.auth}")              private String auth;
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")   private String starttls;
+    @Value("${spring.mail.properties.mail.smtp.ssl.enable}")        private String sslEnable;
+    @Value("${spring.mail.properties.mail.smtp.ssl.trust}")         private String sslTrust;
+    
+    @Bean
+    public JavaMailSender javaMailService() {
+        JavaMailSenderImpl sender = new JavaMailSenderImpl();
+        sender.setHost(host);
+        sender.setUsername(id);
+        sender.setPassword(password);
+        sender.setPort(port);
+        sender.setJavaMailProperties(getMailProperties());
+        sender.setDefaultEncoding(encoding);
+        return sender;
+    }
+    
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.setProperty("mail.transport.protocol", protocol);
+        properties.setProperty("mail.smtp.auth", auth);
+        properties.setProperty("mail.smtp.starttls.enable", starttls);
+        properties.setProperty("mail.debug", debug);
+        properties.setProperty("mail.smtp.ssl.trust", sslTrust);
+        properties.setProperty("mail.smtp.ssl.enable", sslEnable);
+        return properties;
+    }
+
+}

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/config/RedisConfig.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/config/RedisConfig.java
@@ -1,5 +1,6 @@
 package kim.zhyun.serveruser.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -11,9 +12,15 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Configuration
 public class RedisConfig {
     
+    @Value("${spring.data.redis.host}")
+    private String host;
+    
+    @Value("${spring.data.redis.port}")
+    private int port;
+    
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory();
+        return new LettuceConnectionFactory(host, port);
     }
     
     @Bean

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/controller/CheckController.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/controller/CheckController.java
@@ -3,8 +3,11 @@ package kim.zhyun.serveruser.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import kim.zhyun.serveruser.data.ApiResponse;
+import kim.zhyun.serveruser.data.EmailAuthCodeRequest;
+import kim.zhyun.serveruser.data.EmailAuthDto;
 import kim.zhyun.serveruser.service.SignUpService;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.validator.constraints.Length;
@@ -59,13 +62,14 @@ public class CheckController {
 
     @Operation(summary = "이메일로 인증코드 전송")
     @PostMapping("/auth")
-    public void sendEmail() {
-    
+    public void sendEmail(HttpServletRequest request,
+                          @Valid @RequestBody EmailAuthCodeRequest userRequest) {
+        signupService.sendEmailAuthCode(request.getSession().getId(), userRequest);
     }
     
     @Operation(summary = "메일 인증")
     @GetMapping("/auth")
-    public void sendEmail(@RequestParam(name = "code") String code) {
+    public void authEmailCode(@RequestParam(name = "code") String code) {
     
     }
     

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/controller/CheckController.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/controller/CheckController.java
@@ -16,6 +16,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import static kim.zhyun.serveruser.data.message.ExceptionMessage.VALID_EMAIL_EXCEPTION_MESSAGE;
+import static kim.zhyun.serveruser.data.message.ExceptionMessage.VALID_NICKNAME_EXCEPTION_MESSAGE;
 import static kim.zhyun.serveruser.data.message.ResponseMessage.*;
 
 
@@ -31,15 +33,15 @@ public class CheckController {
     @GetMapping
     public ResponseEntity<ApiResponse<Void>> duplicateCheck(HttpServletRequest request,
                                                             @RequestParam(name = "email", required = false)
-                                                            @Email(message = "올바른 이메일 주소를 입력해주세요.", regexp = "^[_a-z0-9-]+(.[_a-z0-9-]+)*@(?:\\w+\\.)+\\w+$")
+                                                            @Email(message = VALID_EMAIL_EXCEPTION_MESSAGE, regexp = "^[_a-z0-9-]+(.[_a-z0-9-]+)*@(?:\\w+\\.)+\\w+$")
                                                             String email,
                                                             @RequestParam(name = "nickname", required = false)
-                                                                @Length(min = 1, max = 6, message = "1글자 이상, 6글자 이하로 입력해주세요.")
+                                                                @Length(min = 1, max = 6, message = VALID_NICKNAME_EXCEPTION_MESSAGE)
                                                                 String nickname) {
         String sessionId = request.getSession().getId();
         
         boolean result = false;
-        ResponseMessage message = SIGN_UP_CHECK_VALUE_IS_EMPTY;
+        String message = SIGN_UP_CHECK_VALUE_IS_EMPTY;
         
         // email 중복확인
         if (email != null) {

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/controller/CheckController.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/controller/CheckController.java
@@ -8,6 +8,7 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import kim.zhyun.serveruser.data.ApiResponse;
 import kim.zhyun.serveruser.data.EmailAuthCodeRequest;
+import kim.zhyun.serveruser.data.message.ResponseMessage;
 import kim.zhyun.serveruser.service.SignUpService;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.validator.constraints.Length;
@@ -37,27 +38,26 @@ public class CheckController {
                                                                 String nickname) {
         String sessionId = request.getSession().getId();
         
+        boolean result = false;
+        ResponseMessage message = SIGN_UP_CHECK_VALUE_IS_EMPTY;
+        
         // email 중복확인
         if (email != null) {
-            return ResponseEntity.ok(ApiResponse.<Void>builder()
-                    .status(true)
-                    .message(signupService.availableEmail(email, sessionId)
-                            ? SIGN_UP_AVAILABLE_EMAIL
-                            : SIGN_UP_UNAVAILABLE_EMAIL).build());
+            result = signupService.availableEmail(email, sessionId);
+            message = result ? SIGN_UP_AVAILABLE_EMAIL
+                             : SIGN_UP_UNAVAILABLE_EMAIL;
         }
         
         // 닉네임 중복확인
         if (nickname != null) {
-            return ResponseEntity.ok(ApiResponse.<Void>builder()
-                    .status(true)
-                    .message(signupService.availableNickname(nickname, sessionId)
-                            ? SIGN_UP_AVAILABLE_NICKNAME
-                            : SIGN_UP_UNAVAILABLE_NICKNAME).build());
+            result = signupService.availableNickname(nickname, sessionId);
+            message = result ? SIGN_UP_AVAILABLE_NICKNAME
+                             : SIGN_UP_UNAVAILABLE_NICKNAME;
         }
         
         return ResponseEntity.ok(ApiResponse.<Void>builder()
-                        .status(false)
-                        .message(SIGN_UP_CHECK_VALUE_IS_EMPTY).build());
+                .status(result)
+                .message(message).build());
     }
 
     @Operation(summary = "이메일로 인증코드 전송")

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/controller/CheckController.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/controller/CheckController.java
@@ -12,7 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import static kim.zhyun.serveruser.data.type.ResponseMessage.*;
+import static kim.zhyun.serveruser.data.message.ResponseMessage.*;
 
 
 @Tag(name = "이메일 인증, 이메일 중복 확인, 닉네임 중복 확인 API")

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/controller/CheckController.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/controller/CheckController.java
@@ -62,9 +62,13 @@ public class CheckController {
 
     @Operation(summary = "이메일로 인증코드 전송")
     @PostMapping("/auth")
-    public void sendEmail(HttpServletRequest request,
+    public ResponseEntity<ApiResponse<Void>> sendEmail(HttpServletRequest request,
                           @Valid @RequestBody EmailAuthCodeRequest userRequest) {
         signupService.sendEmailAuthCode(request.getSession().getId(), userRequest);
+        
+        return ResponseEntity.ok(ApiResponse.<Void>builder()
+                .status(true)
+                .message(SEND_EMAIL_AUTH_CODE).build());
     }
     
     @Operation(summary = "메일 인증코드 검증")

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/controller/CheckController.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/controller/CheckController.java
@@ -5,9 +5,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import kim.zhyun.serveruser.data.ApiResponse;
 import kim.zhyun.serveruser.data.EmailAuthCodeRequest;
-import kim.zhyun.serveruser.data.EmailAuthDto;
 import kim.zhyun.serveruser.service.SignUpService;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.validator.constraints.Length;
@@ -69,8 +69,14 @@ public class CheckController {
     
     @Operation(summary = "메일 인증")
     @GetMapping("/auth")
-    public void authEmailCode(@RequestParam(name = "code") String code) {
-    
+    public ResponseEntity<ApiResponse<Void>> authEmailCode(HttpServletRequest request,
+                              @RequestParam(name = "code")
+                              @NotBlank(message = "코드를 입력해 주세요.") String code) {
+        signupService.verifyEmailAuthCode(request.getSession().getId(), code);
+        
+        return ResponseEntity.ok(ApiResponse.<Void>builder()
+                .status(true)
+                .message(VERIFY_EMAIL_AUTH_SUCCESS).build());
     }
     
 }

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/controller/CheckController.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/controller/CheckController.java
@@ -16,8 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import static kim.zhyun.serveruser.data.message.ExceptionMessage.VALID_EMAIL_EXCEPTION_MESSAGE;
-import static kim.zhyun.serveruser.data.message.ExceptionMessage.VALID_NICKNAME_EXCEPTION_MESSAGE;
+import static kim.zhyun.serveruser.data.message.ExceptionMessage.*;
 import static kim.zhyun.serveruser.data.message.ResponseMessage.*;
 
 
@@ -77,7 +76,7 @@ public class CheckController {
     @GetMapping("/auth")
     public ResponseEntity<ApiResponse<Void>> authEmailCode(HttpServletRequest request,
                               @RequestParam(name = "code")
-                              @NotBlank(message = "코드를 입력해 주세요.") String code) {
+                              @NotBlank(message = VALID_EMAIL_CODE_EXCEPTION_MESSAGE) String code) {
         signupService.verifyEmailAuthCode(request.getSession().getId(), code);
         
         return ResponseEntity.ok(ApiResponse.<Void>builder()

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/controller/CheckController.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/controller/CheckController.java
@@ -67,7 +67,7 @@ public class CheckController {
         signupService.sendEmailAuthCode(request.getSession().getId(), userRequest);
     }
     
-    @Operation(summary = "메일 인증")
+    @Operation(summary = "메일 인증코드 검증")
     @GetMapping("/auth")
     public ResponseEntity<ApiResponse<Void>> authEmailCode(HttpServletRequest request,
                               @RequestParam(name = "code")

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/ApiResponse.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/ApiResponse.java
@@ -27,8 +27,8 @@ public class ApiResponse <T> {
             return ((ResponseMessage) message).getMessage();
         
         if (message instanceof ExceptionMessage)
-            return ((ExceptionMessage) message).getDescription();
+            return ((ExceptionMessage) message).getMessage();
         
-        throw new RuntimeException(RESPONSE_API_MESSAGE_INPUT_FAULT.getDescription());
+        throw new RuntimeException(RESPONSE_API_MESSAGE_INPUT_FAULT.getMessage());
     }
 }

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/ApiResponse.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/ApiResponse.java
@@ -1,7 +1,7 @@
 package kim.zhyun.serveruser.data;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import kim.zhyun.serveruser.data.type.ResponseMessage;
+import kim.zhyun.serveruser.data.message.ResponseMessage;
 import lombok.*;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/ApiResponse.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/ApiResponse.java
@@ -2,14 +2,14 @@ package kim.zhyun.serveruser.data;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import kim.zhyun.serveruser.data.message.ResponseMessage;
-import kim.zhyun.serveruser.data.type.ExceptionType;
+import kim.zhyun.serveruser.data.message.ExceptionMessage;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
-import static kim.zhyun.serveruser.data.type.ExceptionType.RESPONSE_API_MESSAGE_INPUT_FAULT;
+import static kim.zhyun.serveruser.data.message.ExceptionMessage.RESPONSE_API_MESSAGE_INPUT_FAULT;
 
 @NoArgsConstructor
 @AllArgsConstructor
@@ -26,8 +26,8 @@ public class ApiResponse <T> {
         if (message instanceof ResponseMessage)
             return ((ResponseMessage) message).getMessage();
         
-        if (message instanceof ExceptionType)
-            return ((ExceptionType) message).getDescription();
+        if (message instanceof ExceptionMessage)
+            return ((ExceptionMessage) message).getDescription();
         
         throw new RuntimeException(RESPONSE_API_MESSAGE_INPUT_FAULT.getDescription());
     }

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/ApiResponse.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/ApiResponse.java
@@ -2,9 +2,11 @@ package kim.zhyun.serveruser.data;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import kim.zhyun.serveruser.data.message.ResponseMessage;
+import kim.zhyun.serveruser.data.type.ExceptionType;
 import lombok.*;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static kim.zhyun.serveruser.data.type.ExceptionType.RESPONSE_API_MESSAGE_INPUT_FAULT;
 
 @NoArgsConstructor
 @AllArgsConstructor
@@ -15,9 +17,15 @@ public class ApiResponse <T> {
     @Getter private Boolean status;
     @Getter private T result;
     
-    private ResponseMessage message;
+    private Object message;
     
     public String getMessage() {
-        return message.getMessage();
+        if (message instanceof ResponseMessage)
+            return ((ResponseMessage) message).getMessage();
+        
+        if (message instanceof ExceptionType)
+            return ((ExceptionType) message).getDescription();
+        
+        throw new RuntimeException(RESPONSE_API_MESSAGE_INPUT_FAULT.getDescription());
     }
 }

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/ApiResponse.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/ApiResponse.java
@@ -1,34 +1,21 @@
 package kim.zhyun.serveruser.data;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import kim.zhyun.serveruser.data.message.ResponseMessage;
-import kim.zhyun.serveruser.data.message.ExceptionMessage;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
-import static kim.zhyun.serveruser.data.message.ExceptionMessage.RESPONSE_API_MESSAGE_INPUT_FAULT;
 
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
+@Getter @Builder
 @JsonInclude(NON_NULL)
 public class ApiResponse <T> {
     
-    @Getter private Boolean status;
-    @Getter private T result;
+    private Boolean status;
+    private String message;
+    private T result;
     
-    private Object message;
-    
-    public String getMessage() {
-        if (message instanceof ResponseMessage)
-            return ((ResponseMessage) message).getMessage();
-        
-        if (message instanceof ExceptionMessage)
-            return ((ExceptionMessage) message).getMessage();
-        
-        throw new RuntimeException(RESPONSE_API_MESSAGE_INPUT_FAULT.getMessage());
-    }
 }

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/ApiResponse.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/ApiResponse.java
@@ -3,7 +3,10 @@ package kim.zhyun.serveruser.data;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import kim.zhyun.serveruser.data.message.ResponseMessage;
 import kim.zhyun.serveruser.data.type.ExceptionType;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 import static kim.zhyun.serveruser.data.type.ExceptionType.RESPONSE_API_MESSAGE_INPUT_FAULT;

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/EmailAuthCodeRequest.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/EmailAuthCodeRequest.java
@@ -6,6 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.Objects;
+
 @NoArgsConstructor
 @AllArgsConstructor(staticName = "of")
 @Getter
@@ -15,4 +17,13 @@ public class EmailAuthCodeRequest {
     @Email(message = "올바른 이메일 주소를 입력해주세요.", regexp = "^[_a-z0-9-]+(.[_a-z0-9-]+)*@(?:\\w+\\.)+\\w+$")
     private String email;
     
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        
+        EmailAuthCodeRequest that = (EmailAuthCodeRequest) obj;
+        
+        return Objects.equals(email, that.email);
+    }
 }

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/EmailAuthCodeRequest.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/EmailAuthCodeRequest.java
@@ -1,0 +1,16 @@
+package kim.zhyun.serveruser.data;
+
+import jakarta.validation.constraints.Email;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor(staticName = "of")
+@Getter
+public class EmailAuthCodeRequest {
+    
+    @Email(message = "올바른 이메일 주소를 입력해주세요.", regexp = "^[_a-z0-9-]+(.[_a-z0-9-]+)*@(?:\\w+\\.)+\\w+$")
+    private String email;
+    
+}

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/EmailAuthCodeRequest.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/EmailAuthCodeRequest.java
@@ -1,6 +1,7 @@
 package kim.zhyun.serveruser.data;
 
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,6 +11,7 @@ import lombok.NoArgsConstructor;
 @Getter
 public class EmailAuthCodeRequest {
     
+    @NotBlank(message = "올바른 이메일 주소를 입력해주세요.")
     @Email(message = "올바른 이메일 주소를 입력해주세요.", regexp = "^[_a-z0-9-]+(.[_a-z0-9-]+)*@(?:\\w+\\.)+\\w+$")
     private String email;
     

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/NicknameDto.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/NicknameDto.java
@@ -1,6 +1,5 @@
 package kim.zhyun.serveruser.data;
 
-import kim.zhyun.serveruser.entity.SessionUser;
 import lombok.*;
 
 import java.util.Objects;

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/entity/Role.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/entity/Role.java
@@ -1,4 +1,4 @@
-package kim.zhyun.serveruser.entity;
+package kim.zhyun.serveruser.data.entity;
 
 
 import jakarta.persistence.Column;

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/entity/SessionUser.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/entity/SessionUser.java
@@ -1,4 +1,4 @@
-package kim.zhyun.serveruser.entity;
+package kim.zhyun.serveruser.data.entity;
 
 import lombok.*;
 import org.springframework.data.annotation.Id;

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/entity/User.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/entity/User.java
@@ -1,4 +1,4 @@
-package kim.zhyun.serveruser.entity;
+package kim.zhyun.serveruser.data.entity;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/message/ExceptionMessage.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/message/ExceptionMessage.java
@@ -13,8 +13,10 @@ public enum ExceptionMessage {
     VERIFY_EMAIL_AUTH_CODE_EXPIRED("인증 번호가 만료되었습니다. 인증을 다시 진행해주세요!"),
     VERIFY_FAIL_EMAIL_AUTH_CODE("인증 번호가 일치하지 않습니다."),
     
+    REQUIRED_REQUEST_BODY("Required request body is missing"),
+    
     RESPONSE_API_MESSAGE_INPUT_FAULT("\"api response message\" 타입이 잘못 입력되었습니다 😮");
     ;
     
-    private final String description;
+    private final String message;
 }

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/message/ExceptionMessage.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/message/ExceptionMessage.java
@@ -1,22 +1,22 @@
 package kim.zhyun.serveruser.data.message;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
-public enum ExceptionMessage {
-    NOT_FOUND_SESSION("사용자를 찾을 수 없습니다."),
-    MAIL_SEND_FAIL("메일 발송에 실패했습니다. 다른 이메일 주소를 사용해주세요."),
-    REQUIRE_MAIL_DUPLICATE_CHECK("이메일 중복 확인을 먼저 진행해 주세요."),
+public class ExceptionMessage {
     
-    VERIFY_EMAIL_AUTH_CODE_EXPIRED("인증 번호가 만료되었습니다. 인증을 다시 진행해주세요!"),
-    VERIFY_FAIL_EMAIL_AUTH_CODE("인증 번호가 일치하지 않습니다."),
+    // email 관련
+    public static final String MAIL_SEND_FAIL = "메일 발송에 실패했습니다. 다른 이메일 주소를 사용해주세요.";
+    public static final String REQUIRE_MAIL_DUPLICATE_CHECK = "이메일 중복 확인을 먼저 진행해 주세요.";
+    public static final String VERIFY_EMAIL_AUTH_CODE_EXPIRED = "인증 번호가 만료되었습니다. 인증을 다시 진행해주세요!";
+    public static final String VERIFY_FAIL_EMAIL_AUTH_CODE = "인증 번호가 일치하지 않습니다.";
+    public static final String VALID_EMAIL_EXCEPTION_MESSAGE = "올바른 이메일 주소를 입력해주세요.";
     
-    REQUIRED_REQUEST_BODY("Required request body is missing"),
+    // nickname 관련
+    public static final String VALID_NICKNAME_EXCEPTION_MESSAGE = "1글자 이상, 6글자 이하로 입력해주세요.";
     
-    RESPONSE_API_MESSAGE_INPUT_FAULT("\"api response message\" 타입이 잘못 입력되었습니다 😮");
-    ;
+    // 공통
+    public static final String VALID_EXCEPTION = "입력 값이 올바르지 않습니다.";
+    public static final String REQUIRED_REQUEST_BODY = "Required request body is missing";
     
-    private final String message;
 }

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/message/ExceptionMessage.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/message/ExceptionMessage.java
@@ -1,16 +1,17 @@
-package kim.zhyun.serveruser.data.type;
+package kim.zhyun.serveruser.data.message;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum ExceptionType {
+public enum ExceptionMessage {
     NOT_FOUND_SESSION("사용자를 찾을 수 없습니다."),
     MAIL_SEND_FAIL("메일 발송에 실패했습니다. 다른 이메일 주소를 사용해주세요."),
     REQUIRE_MAIL_DUPLICATE_CHECK("이메일 중복 확인을 먼저 진행해 주세요."),
     
     VERIFY_EMAIL_AUTH_CODE_EXPIRED("인증 번호가 만료되었습니다. 인증을 다시 진행해주세요!"),
+    VERIFY_FAIL_EMAIL_AUTH_CODE("인증 번호가 일치하지 않습니다."),
     
     RESPONSE_API_MESSAGE_INPUT_FAULT("\"api response message\" 타입이 잘못 입력되었습니다 😮");
     ;

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/message/ExceptionMessage.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/message/ExceptionMessage.java
@@ -11,6 +11,7 @@ public class ExceptionMessage {
     public static final String VERIFY_EMAIL_AUTH_CODE_EXPIRED = "인증 번호가 만료되었습니다. 인증을 다시 진행해주세요!";
     public static final String VERIFY_FAIL_EMAIL_AUTH_CODE = "인증 번호가 일치하지 않습니다.";
     public static final String VALID_EMAIL_EXCEPTION_MESSAGE = "올바른 이메일 주소를 입력해주세요.";
+    public static final String VALID_EMAIL_CODE_EXCEPTION_MESSAGE = "인증 코드를 입력해 주세요.";
     
     // nickname 관련
     public static final String VALID_NICKNAME_EXCEPTION_MESSAGE = "1글자 이상, 6글자 이하로 입력해주세요.";

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/message/ResponseMessage.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/message/ResponseMessage.java
@@ -14,6 +14,8 @@ public enum ResponseMessage {
 
     SIGN_UP_CHECK_VALUE_IS_EMPTY("값을 입력해주세요."),
     VALID_EXCEPTION("입력 값이 올바르지 않습니다."),
+    
+    VERIFY_EMAIL_AUTH_SUCCESS("인증되었습니다."),
     ;
     
     private final String message;

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/message/ResponseMessage.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/message/ResponseMessage.java
@@ -1,4 +1,4 @@
-package kim.zhyun.serveruser.data.type;
+package kim.zhyun.serveruser.data.message;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/message/ResponseMessage.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/message/ResponseMessage.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum ResponseMessage {
     SIGN_UP_AVAILABLE_EMAIL("사용 가능한 이메일입니다. 이메일 인증을 진행해주세요."),
     SIGN_UP_UNAVAILABLE_EMAIL("이미 사용중인 이메일입니다."),
+    SEND_EMAIL_AUTH_CODE("인증 코드가 전송되었습니다."),
+    VERIFY_EMAIL_AUTH_SUCCESS("인증되었습니다."),
     
     SIGN_UP_AVAILABLE_NICKNAME("사용 가능한 닉네임입니다."),
     SIGN_UP_UNAVAILABLE_NICKNAME("이미 사용중인 닉네임입니다."),
@@ -15,7 +17,6 @@ public enum ResponseMessage {
     SIGN_UP_CHECK_VALUE_IS_EMPTY("값을 입력해주세요."),
     VALID_EXCEPTION("입력 값이 올바르지 않습니다."),
     
-    VERIFY_EMAIL_AUTH_SUCCESS("인증되었습니다."),
     ;
     
     private final String message;

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/message/ResponseMessage.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/message/ResponseMessage.java
@@ -1,23 +1,20 @@
 package kim.zhyun.serveruser.data.message;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
-public enum ResponseMessage {
-    SIGN_UP_AVAILABLE_EMAIL("사용 가능한 이메일입니다. 이메일 인증을 진행해주세요."),
-    SIGN_UP_UNAVAILABLE_EMAIL("이미 사용중인 이메일입니다."),
-    SEND_EMAIL_AUTH_CODE("인증 코드가 전송되었습니다."),
-    VERIFY_EMAIL_AUTH_SUCCESS("인증되었습니다."),
+public class ResponseMessage {
+    // email 관련
+    public static final String SIGN_UP_AVAILABLE_EMAIL = "사용 가능한 이메일입니다. 이메일 인증을 진행해주세요.";
+    public static final String SIGN_UP_UNAVAILABLE_EMAIL = "이미 사용중인 이메일입니다.";
+    public static final String SEND_EMAIL_AUTH_CODE = "인증 코드가 전송되었습니다.";
+    public static final String VERIFY_EMAIL_AUTH_SUCCESS = "인증되었습니다.";
     
-    SIGN_UP_AVAILABLE_NICKNAME("사용 가능한 닉네임입니다."),
-    SIGN_UP_UNAVAILABLE_NICKNAME("이미 사용중인 닉네임입니다."),
-
-    SIGN_UP_CHECK_VALUE_IS_EMPTY("값을 입력해주세요."),
-    VALID_EXCEPTION("입력 값이 올바르지 않습니다."),
+    // nickname 관련
+    public static final String SIGN_UP_AVAILABLE_NICKNAME = "사용 가능한 닉네임입니다.";
+    public static final String SIGN_UP_UNAVAILABLE_NICKNAME = "이미 사용중인 닉네임입니다.";
     
-    ;
+    // sign-up 값 체크 기본 응답
+    public static final String SIGN_UP_CHECK_VALUE_IS_EMPTY = "값을 입력해주세요.";
     
-    private final String message;
 }

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/type/ExceptionType.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/type/ExceptionType.java
@@ -10,7 +10,9 @@ public enum ExceptionType {
     MAIL_SEND_FAIL("메일 발송에 실패했습니다. 다른 이메일 주소를 사용해주세요."),
     REQUIRE_MAIL_DUPLICATE_CHECK("이메일 중복 확인을 먼저 진행해 주세요."),
     
-    RESPONSE_API_MESSAGE_INPUT_FAULT("api response \"message\"가 잘못 입력되었습니다😮");
+    VERIFY_EMAIL_AUTH_CODE_EXPIRED("인증 번호가 만료되었습니다. 인증을 다시 진행해주세요!"),
+    
+    RESPONSE_API_MESSAGE_INPUT_FAULT("\"api response message\" 타입이 잘못 입력되었습니다 😮");
     ;
     
     private final String description;

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/type/ExceptionType.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/data/type/ExceptionType.java
@@ -6,7 +6,11 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ExceptionType {
-    NOT_FOUND_SESSION("사용자를 찾을 수 없습니다.")
+    NOT_FOUND_SESSION("사용자를 찾을 수 없습니다."),
+    MAIL_SEND_FAIL("메일 발송에 실패했습니다. 다른 이메일 주소를 사용해주세요."),
+    REQUIRE_MAIL_DUPLICATE_CHECK("이메일 중복 확인을 먼저 진행해 주세요."),
+    
+    RESPONSE_API_MESSAGE_INPUT_FAULT("api response \"message\"가 잘못 입력되었습니다😮");
     ;
     
     private final String description;

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/interceptor/ConnectionInterceptor.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/interceptor/ConnectionInterceptor.java
@@ -3,7 +3,7 @@ package kim.zhyun.serveruser.interceptor;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
-import kim.zhyun.serveruser.entity.SessionUser;
+import kim.zhyun.serveruser.data.entity.SessionUser;
 import kim.zhyun.serveruser.service.SessionUserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/interceptor/DisconnectionInterceptor.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/interceptor/DisconnectionInterceptor.java
@@ -4,7 +4,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import kim.zhyun.serveruser.data.NicknameDto;
-import kim.zhyun.serveruser.entity.SessionUser;
+import kim.zhyun.serveruser.data.entity.SessionUser;
 import kim.zhyun.serveruser.service.NicknameReserveService;
 import kim.zhyun.serveruser.service.SessionUserService;
 import lombok.RequiredArgsConstructor;

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/repository/RoleRepository.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/repository/RoleRepository.java
@@ -1,7 +1,6 @@
 package kim.zhyun.serveruser.repository;
 
-import kim.zhyun.serveruser.entity.Role;
-import org.springframework.data.jpa.repository.JpaRepository;
+import kim.zhyun.serveruser.data.entity.Role;
 
 import java.util.Optional;
 

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/repository/SessionUserRepository.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/repository/SessionUserRepository.java
@@ -1,6 +1,6 @@
 package kim.zhyun.serveruser.repository;
 
-import kim.zhyun.serveruser.entity.SessionUser;
+import kim.zhyun.serveruser.data.entity.SessionUser;
 import org.springframework.data.repository.CrudRepository;
 
 public interface SessionUserRepository extends CrudRepository<SessionUser, String> {

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/repository/UserRepository.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/repository/UserRepository.java
@@ -1,6 +1,6 @@
 package kim.zhyun.serveruser.repository;
 
-import kim.zhyun.serveruser.entity.User;
+import kim.zhyun.serveruser.data.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/service/EmailService.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/service/EmailService.java
@@ -5,6 +5,7 @@ import kim.zhyun.serveruser.data.EmailAuthDto;
 public interface EmailService {
     
     boolean existEmail(EmailAuthDto dto);
+    void sendEmailAuthCode(String userEmail);
     boolean existCode(EmailAuthDto dto);
     void saveEmailAuthCode(EmailAuthDto dto);
     void deleteAndUpdateSessionUserEmail(EmailAuthDto dto, String sessionId);

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/service/SessionUserService.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/service/SessionUserService.java
@@ -2,9 +2,7 @@ package kim.zhyun.serveruser.service;
 
 import kim.zhyun.serveruser.data.SessionUserEmailUpdate;
 import kim.zhyun.serveruser.data.SessionUserNicknameUpdate;
-import kim.zhyun.serveruser.entity.SessionUser;
-
-import java.util.Optional;
+import kim.zhyun.serveruser.data.entity.SessionUser;
 
 public interface SessionUserService {
     

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/service/SignUpService.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/service/SignUpService.java
@@ -1,6 +1,9 @@
 package kim.zhyun.serveruser.service;
 
+import kim.zhyun.serveruser.data.EmailAuthCodeRequest;
+
 public interface SignUpService {
     boolean availableEmail(String email, String sessionId);
     boolean availableNickname(String nickname, String sessionId);
+    void sendEmailAuthCode(String sessionId, EmailAuthCodeRequest request);
 }

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/service/SignUpService.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/service/SignUpService.java
@@ -6,4 +6,5 @@ public interface SignUpService {
     boolean availableEmail(String email, String sessionId);
     boolean availableNickname(String nickname, String sessionId);
     void sendEmailAuthCode(String sessionId, EmailAuthCodeRequest request);
+    void verifyEmailAuthCode(String sessionId, String code);
 }

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/service/impl/EmailServiceImpl.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/service/impl/EmailServiceImpl.java
@@ -19,7 +19,7 @@ import java.io.UnsupportedEncodingException;
 import java.util.UUID;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static kim.zhyun.serveruser.data.type.ExceptionType.MAIL_SEND_FAIL;
+import static kim.zhyun.serveruser.data.message.ExceptionMessage.MAIL_SEND_FAIL;
 
 @Slf4j
 @RequiredArgsConstructor

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/service/impl/EmailServiceImpl.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/service/impl/EmailServiceImpl.java
@@ -1,5 +1,9 @@
 package kim.zhyun.serveruser.service.impl;
 
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import kim.zhyun.serveruser.advice.MailAuthException;
 import kim.zhyun.serveruser.data.EmailAuthDto;
 import kim.zhyun.serveruser.data.SessionUserEmailUpdate;
 import kim.zhyun.serveruser.service.EmailService;
@@ -8,9 +12,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
+import java.io.UnsupportedEncodingException;
+import java.util.UUID;
+
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static kim.zhyun.serveruser.data.type.ExceptionType.MAIL_SEND_FAIL;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -18,12 +27,32 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public class EmailServiceImpl implements EmailService {
     private final RedisTemplate<String, String> template;
     private final SessionUserService sessionUserService;
+    private final JavaMailSender mailSender;
+    
     
     @Value("${sign-up.email.expire}")   private long expireTime;
     
     @Override
     public boolean existEmail(EmailAuthDto dto) {
         return template.hasKey(dto.getEmail());
+    }
+    
+    @Override
+    public void sendEmailAuthCode(String userEmail) {
+        try {
+            String authCode = getCode();
+            EmailAuthDto saveEmailInfo = EmailAuthDto.builder()
+                    .email(userEmail)
+                    .code(authCode).build();
+            
+            MimeMessage message = createMessage(userEmail, authCode);
+            mailSender.send(message);
+            
+            saveEmailAuthCode(saveEmailInfo);
+            
+        } catch (Exception e) {
+            throw new MailAuthException(MAIL_SEND_FAIL);
+        }
     }
     
     @Override
@@ -48,4 +77,29 @@ public class EmailServiceImpl implements EmailService {
         sessionUserService.updateEmail(sessionUserEmailUpdate);
     }
     
+    private MimeMessage createMessage(String to, String code) throws MessagingException, UnsupportedEncodingException {
+        MimeMessage  message = mailSender.createMimeMessage();
+        
+        message.addRecipients(MimeMessage.RecipientType.TO, to);
+        message.setSubject(String.format("[Simple Board 02] 회원가입 인증 코드 [%s]", code));
+        
+        String body = String.format("""
+        <br>
+        <hr>
+        <br>
+        <h1><center><span>💣 1분 안에 아래의 인증 코드를 입력해주세요 🤗</span></center></h1>
+        <h3><center><span>%s</span></center></h3>
+        <br>
+        <hr>
+        <br>
+        """, code);
+        
+        message.setText(body, "utf-8", "html");
+        message.setFrom(new InternetAddress("no-reply@simpleboard.02","SB02-ADMIN"));
+        return message;
+    }
+    
+    private String getCode() {
+        return UUID.randomUUID().toString().replace("-", "").substring(1, 7);
+    }
 }

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/service/impl/NicknameReserveServiceImpl.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/service/impl/NicknameReserveServiceImpl.java
@@ -1,7 +1,7 @@
 package kim.zhyun.serveruser.service.impl;
 
 import kim.zhyun.serveruser.data.NicknameDto;
-import kim.zhyun.serveruser.entity.SessionUser;
+import kim.zhyun.serveruser.data.entity.SessionUser;
 import kim.zhyun.serveruser.repository.SessionUserRepository;
 import kim.zhyun.serveruser.service.NicknameReserveService;
 import lombok.Getter;

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/service/impl/SessionUserServiceImpl.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/service/impl/SessionUserServiceImpl.java
@@ -7,6 +7,7 @@ import kim.zhyun.serveruser.repository.SessionUserRepository;
 import kim.zhyun.serveruser.service.SessionUserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -14,6 +15,9 @@ import org.springframework.stereotype.Service;
 @Service
 public class SessionUserServiceImpl implements SessionUserService {
     private final SessionUserRepository sessionUserRepository;
+    
+    @Value("${sign-up.key.email}")      private String KEY_EMAIL;
+    @Value("${sign-up.key.nickname}")   private String KEY_NICKNAME;
     
     @Override
     public SessionUser findById(String id) {
@@ -35,7 +39,7 @@ public class SessionUserServiceImpl implements SessionUserService {
     @Override
     public SessionUser updateEmail(SessionUserEmailUpdate update) {
         SessionUser source = findById(update.getId());
-        source.setEmail(update.getEmail());
+        source.setEmail(update.getEmail().replace(KEY_EMAIL, ""));
         source.setEmailVerification(update.isEmailVerification());
         return save(source);
     }
@@ -43,7 +47,7 @@ public class SessionUserServiceImpl implements SessionUserService {
     @Override
     public SessionUser updateNickname(SessionUserNicknameUpdate update) {
         SessionUser source = findById(update.getId());
-        source.setNickname(update.getNickname());
+        source.setNickname(update.getNickname().replace(KEY_NICKNAME, ""));
         return save(source);
     }
     

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/service/impl/SessionUserServiceImpl.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/service/impl/SessionUserServiceImpl.java
@@ -1,18 +1,13 @@
 package kim.zhyun.serveruser.service.impl;
 
-import kim.zhyun.serveruser.advice.NotFoundSessionException;
 import kim.zhyun.serveruser.data.SessionUserEmailUpdate;
 import kim.zhyun.serveruser.data.SessionUserNicknameUpdate;
-import kim.zhyun.serveruser.entity.SessionUser;
+import kim.zhyun.serveruser.data.entity.SessionUser;
 import kim.zhyun.serveruser.repository.SessionUserRepository;
 import kim.zhyun.serveruser.service.SessionUserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-
-import java.util.Optional;
-
-import static kim.zhyun.serveruser.data.type.ExceptionType.NOT_FOUND_SESSION;
 
 @Slf4j
 @RequiredArgsConstructor

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/service/impl/SignUpServiceImpl.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/service/impl/SignUpServiceImpl.java
@@ -84,7 +84,7 @@ public class SignUpServiceImpl implements SignUpService {
         if (!emailService.existEmail(requestInfo))
             throw new MailAuthException(VERIFY_EMAIL_AUTH_CODE_EXPIRED);
         
-        // 코드 불일치 case 2 : 코드 잘못 입력
+        // 코드 불일치 case 2 : 코드 불일치
         if (!emailService.existCode(requestInfo))
             throw new MailAuthException(VERIFY_FAIL_EMAIL_AUTH_CODE);
         

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/service/impl/SignUpServiceImpl.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/service/impl/SignUpServiceImpl.java
@@ -1,7 +1,7 @@
 package kim.zhyun.serveruser.service.impl;
 
 import kim.zhyun.serveruser.data.NicknameDto;
-import kim.zhyun.serveruser.entity.SessionUser;
+import kim.zhyun.serveruser.data.entity.SessionUser;
 import kim.zhyun.serveruser.repository.UserRepository;
 import kim.zhyun.serveruser.service.NicknameReserveService;
 import kim.zhyun.serveruser.service.SessionUserService;

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/service/impl/SignUpServiceImpl.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/service/impl/SignUpServiceImpl.java
@@ -13,8 +13,7 @@ import kim.zhyun.serveruser.service.SignUpService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import static kim.zhyun.serveruser.data.type.ExceptionType.REQUIRE_MAIL_DUPLICATE_CHECK;
-import static kim.zhyun.serveruser.data.type.ExceptionType.VERIFY_EMAIL_AUTH_CODE_EXPIRED;
+import static kim.zhyun.serveruser.data.message.ExceptionMessage.*;
 
 @RequiredArgsConstructor
 @Service
@@ -87,7 +86,7 @@ public class SignUpServiceImpl implements SignUpService {
         
         // 코드 불일치 case 2 : 코드 잘못 입력
         if (!emailService.existCode(requestInfo))
-            throw new MailAuthException(VERIFY_EMAIL_AUTH_CODE_EXPIRED);
+            throw new MailAuthException(VERIFY_FAIL_EMAIL_AUTH_CODE);
         
         // 인증 성공
         emailService.deleteAndUpdateSessionUserEmail(requestInfo, sessionId);

--- a/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/service/impl/SignUpServiceImpl.java
+++ b/simpleBoard02/server-b-user/src/main/java/kim/zhyun/serveruser/service/impl/SignUpServiceImpl.java
@@ -98,6 +98,7 @@ public class SignUpServiceImpl implements SignUpService {
     private void saveEmailToSessionUserStorage(String email, String sessionId) {
         SessionUser sessionUser = sessionUserService.findById(sessionId);
         sessionUser.setEmail(email);
+        sessionUser.setEmailVerification(false);
         sessionUserService.save(sessionUser);
     }
     

--- a/simpleBoard02/server-b-user/src/main/resources/application.yml
+++ b/simpleBoard02/server-b-user/src/main/resources/application.yml
@@ -46,6 +46,11 @@ spring:
           starttls:
             enable: true
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
 logging:
   level:
     org.hibernate.sql: debug

--- a/simpleBoard02/server-b-user/src/main/resources/application.yml
+++ b/simpleBoard02/server-b-user/src/main/resources/application.yml
@@ -2,6 +2,9 @@ server:
   port: 8090
 
 spring:
+  config:
+    import: classpath:password.yml
+
   h2:
     console:
       path: /h2-console
@@ -24,6 +27,24 @@ spring:
         show_sql: true
         format_sql: true
         highlight_sql: true
+
+  mail:
+    protocol: smtp
+    host: smtp.gmail.com
+    port: 465
+    username: gimwlgus@gmail.com
+    password: ${email.password.gmail}
+    default-encoding: UTF-8
+    properties:
+      debug: true
+      mail:
+        smtp:
+          auth: true
+          ssl:
+            enable: true
+            trust: smtp.gmail.com
+          starttls:
+            enable: true
 
 logging:
   level:

--- a/simpleBoard02/server-b-user/src/test/http/SignUp.http
+++ b/simpleBoard02/server-b-user/src/test/http/SignUp.http
@@ -1,0 +1,10 @@
+### 이메일 중복 확인
+GET http://localhost:8090/check?email=gimwlgus@dasum.net
+
+### 이메일 전송
+POST http://localhost:8090/check/auth
+Content-Type: application/json
+
+{
+  "email": "gimwlgus@dasum.net"
+}

--- a/simpleBoard02/server-b-user/src/test/http/SignUp.http
+++ b/simpleBoard02/server-b-user/src/test/http/SignUp.http
@@ -1,13 +1,17 @@
 ### 닉네임 중복 확인
-GET http://localhost:8090/check?nickname=얼구스
+GET http://localhost:8090/check?nickname=얼거스
 
 ### 이메일 중복 확인
-GET http://localhost:8090/check?email=gimwlgus@dasum.net
+GET http://localhost:8090/check?email=gimwlgus@daum.net
 
 ### 이메일 전송
 POST http://localhost:8090/check/auth
 Content-Type: application/json
 
 {
-  "email": "gimwlgus@dasum.net"
+  "email": "gimwlgus@daum.net"
 }
+
+### 이메일 인증 코드 검증
+GET http://localhost:8090/check/auth?code=54aee4
+

--- a/simpleBoard02/server-b-user/src/test/http/SignUp.http
+++ b/simpleBoard02/server-b-user/src/test/http/SignUp.http
@@ -1,3 +1,6 @@
+### 닉네임 중복 확인
+GET http://localhost:8090/check?nickname=얼구스
+
 ### 이메일 중복 확인
 GET http://localhost:8090/check?email=gimwlgus@dasum.net
 

--- a/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/controller/CheckControllerTest.java
+++ b/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/controller/CheckControllerTest.java
@@ -12,7 +12,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static kim.zhyun.serveruser.data.type.ResponseMessage.*;
+import static kim.zhyun.serveruser.data.message.ResponseMessage.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;

--- a/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/controller/CheckControllerTest.java
+++ b/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/controller/CheckControllerTest.java
@@ -1,5 +1,7 @@
 package kim.zhyun.serveruser.controller;
 
+import kim.zhyun.serveruser.advice.MailAuthException;
+import kim.zhyun.serveruser.data.EmailAuthCodeRequest;
 import kim.zhyun.serveruser.repository.container.RedisTestContainer;
 import kim.zhyun.serveruser.service.SignUpService;
 import lombok.extern.slf4j.Slf4j;
@@ -10,12 +12,18 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
+import static kim.zhyun.serveruser.data.message.ExceptionMessage.REQUIRED_REQUEST_BODY;
+import static kim.zhyun.serveruser.data.message.ExceptionMessage.REQUIRE_MAIL_DUPLICATE_CHECK;
 import static kim.zhyun.serveruser.data.message.ResponseMessage.*;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -29,12 +37,16 @@ class CheckControllerTest {
     private final String NICKNAME = "얼거스";
     private final String EMAIL = "gimwlgus@gmail.com";
     
+    private final String EMAIL_VALID_EXCEPTION_MESSAGE = "올바른 이메일 주소를 입력해주세요.";
+    
     @MockBean
     private SignUpService signupService;
     
     private final MockMvc mvc;
+    private final ObjectMapper mapper;
     public CheckControllerTest(@Autowired MockMvc mvc) {
         this.mvc = mvc;
+        this.mapper = new ObjectMapper();
     }
     
     @DisplayName("중복 확인 - 빈 값 입력")
@@ -53,31 +65,33 @@ class CheckControllerTest {
     @DisplayName("닉네임 중복 확인 - 사용 가능")
     @Test
     void duplicate_check_nickname() throws Exception {
-        when(signupService.availableNickname(anyString(), anyString())).thenReturn(true);
+        MockHttpSession session = new MockHttpSession();
+        String sessionId = session.getId();
+        when(signupService.availableNickname(NICKNAME, sessionId)).thenReturn(true);
         
-        mvc.perform(get("/check").param("nickname", NICKNAME))
+        mvc.perform(get("/check").param("nickname", NICKNAME).session(session))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("status").value(true))
                 .andExpect(jsonPath("message").value(SIGN_UP_AVAILABLE_NICKNAME.getMessage()))
                 .andDo(print());
-        
-        verify(signupService, times(0)).availableEmail(anyString(), anyString());
-        verify(signupService, times(1)).availableNickname(anyString(), anyString());
     }
     
     @DisplayName("닉네임 중복 확인 - 사용 불가")
     @Test
     void duplicate_check_nickname_using() throws Exception {
-        when(signupService.availableNickname(anyString(), anyString())).thenReturn(false);
+        MockHttpSession session = new MockHttpSession();
+        String sessionId = session.getId();
+        when(signupService.availableNickname(NICKNAME, sessionId)).thenReturn(false);
         
-        mvc.perform(get("/check").param("nickname", NICKNAME))
+        mvc.perform(get("/check").param("nickname", NICKNAME)
+                        .session(session))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("status").value(false))
                 .andExpect(jsonPath("message").value(SIGN_UP_UNAVAILABLE_NICKNAME.getMessage()))
                 .andDo(print());
         
-        verify(signupService, times(0)).availableEmail(anyString(), anyString());
-        verify(signupService, times(1)).availableNickname(anyString(), anyString());
+        verify(signupService, times(0)).availableEmail(EMAIL, sessionId);
+        verify(signupService, times(1)).availableNickname(NICKNAME, sessionId);
     }
     
     @DisplayName("닉네임 중복 확인 - 유효한 형식이 아님")
@@ -133,7 +147,7 @@ class CheckControllerTest {
                 .andExpect(jsonPath("$.status").value(false))
                 .andExpect(jsonPath("$.message").value(VALID_EXCEPTION.getMessage()))
                 .andExpect(jsonPath("$.result.[0].field").value("email"))
-                .andExpect(jsonPath("$.result.[0].message").value("올바른 이메일 주소를 입력해주세요."))
+                .andExpect(jsonPath("$.result.[0].message").value(EMAIL_VALID_EXCEPTION_MESSAGE))
                 .andDo(print());
         
         verify(signupService, times(0)).availableEmail(anyString(), anyString());
@@ -148,10 +162,113 @@ class CheckControllerTest {
                 .andExpect(jsonPath("$.status").value(false))
                 .andExpect(jsonPath("$.message").value(VALID_EXCEPTION.getMessage()))
                 .andExpect(jsonPath("$.result.[0].field").value("email"))
-                .andExpect(jsonPath("$.result.[0].message").value("올바른 이메일 주소를 입력해주세요."))
+                .andExpect(jsonPath("$.result.[0].message").value(EMAIL_VALID_EXCEPTION_MESSAGE))
                 .andDo(print());
         
         verify(signupService, times(0)).availableEmail(anyString(), anyString());
         verify(signupService, times(0)).availableNickname(anyString(), anyString());
+    }
+    
+    @DisplayName("인증 코드 메일 발송 - request body is empty")
+    @Test
+    void send_email_fail_not_input_email() throws Exception {
+        // when-then
+        mvc.perform(post("/check/auth")
+                        .contentType(APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(false))
+                .andExpect(jsonPath("$.message").value(REQUIRED_REQUEST_BODY.getMessage()))
+                .andDo(print());
+        
+        verify(signupService, times(0)).sendEmailAuthCode("", null);
+    }
+    
+    @DisplayName("인증 코드 메일 발송 - 이메일 입력 안됨")
+    @Test
+    void send_email_fail_email_valid_exception_null() throws Exception {
+        // given
+        EmailAuthCodeRequest given = EmailAuthCodeRequest.of(null);
+        
+        // when-then
+        mvc.perform(post("/check/auth")
+                        .contentType(APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(given)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(false))
+                .andExpect(jsonPath("$.message").value(VALID_EXCEPTION.getMessage()))
+                .andExpect(jsonPath("$.result.[0].field").value("email"))
+                .andExpect(jsonPath("$.result.[0].message").value(EMAIL_VALID_EXCEPTION_MESSAGE))
+                .andDo(print());
+        
+        verify(signupService, times(0)).sendEmailAuthCode("", given);
+    }
+    
+    @DisplayName("인증 코드 메일 발송 - 이메일 형식 오류")
+    @Test
+    void send_email_fail_email_valid_exception() throws Exception {
+        // given
+        EmailAuthCodeRequest given = EmailAuthCodeRequest.of("test@asd");
+        
+        // when-then
+        mvc.perform(post("/check/auth")
+                        .contentType(APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(given)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(false))
+                .andExpect(jsonPath("$.message").value(VALID_EXCEPTION.getMessage()))
+                .andExpect(jsonPath("$.result.[0].field").value("email"))
+                .andExpect(jsonPath("$.result.[0].message").value(EMAIL_VALID_EXCEPTION_MESSAGE))
+                .andDo(print());
+        
+        verify(signupService, times(0)).sendEmailAuthCode("", given);
+    }
+    
+    @DisplayName("인증 코드 메일 발송 - fail : 이메일 중복검사 안함")
+    @Test
+    void send_email_fail_email_duplicate_check_pass() throws Exception {
+        // given
+        MockHttpSession session = new MockHttpSession();
+        String sessionId = session.getId();
+        
+        EmailAuthCodeRequest given = EmailAuthCodeRequest.of(EMAIL);
+        
+        doThrow(new MailAuthException(REQUIRE_MAIL_DUPLICATE_CHECK))
+                .when(signupService).sendEmailAuthCode(sessionId, given);
+        
+        // when-then
+        mvc.perform(post("/check/auth")
+                        .contentType(APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(given))
+                        .session(session))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(false))
+                .andExpect(jsonPath("$.message").value(REQUIRE_MAIL_DUPLICATE_CHECK.getMessage()))
+                .andDo(print());
+        
+        verify(signupService, times(1)).sendEmailAuthCode(sessionId, given);
+    }
+    
+    @DisplayName("인증 코드 메일 발송 - success")
+    @Test
+    void send_email_success() throws Exception {
+        // given
+        MockHttpSession session = new MockHttpSession();
+        String sessionId = session.getId();
+        
+        EmailAuthCodeRequest given = EmailAuthCodeRequest.of(EMAIL);
+        
+        doNothing().when(signupService).sendEmailAuthCode(sessionId, given);
+        
+        // when-then
+        mvc.perform(post("/check/auth")
+                        .contentType(APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(given))
+                        .session(session))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(true))
+                .andExpect(jsonPath("$.message").value(SEND_EMAIL_AUTH_CODE.getMessage()))
+                .andDo(print());
+        
+        verify(signupService, times(1)).sendEmailAuthCode(sessionId, given);
     }
 }

--- a/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/controller/CheckControllerTest.java
+++ b/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/controller/CheckControllerTest.java
@@ -6,6 +6,7 @@ import kim.zhyun.serveruser.repository.container.RedisTestContainer;
 import kim.zhyun.serveruser.service.SignUpService;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -61,213 +62,229 @@ class CheckControllerTest {
         verify(signupService, times(0)).availableNickname(anyString(), anyString());
     }
     
-    @DisplayName("닉네임 중복 확인 - 사용 가능")
-    @Test
-    void duplicate_check_nickname() throws Exception {
-        MockHttpSession session = new MockHttpSession();
-        String sessionId = session.getId();
-        when(signupService.availableNickname(NICKNAME, sessionId)).thenReturn(true);
+    @DisplayName("닉네임 중복확인")
+    @Nested
+    class DuplicateNicknameTest {
+
+        @DisplayName("사용 가능")
+        @Test
+        void duplicate_check_nickname() throws Exception {
+            MockHttpSession session = new MockHttpSession();
+            String sessionId = session.getId();
+            when(signupService.availableNickname(NICKNAME, sessionId)).thenReturn(true);
+            
+            mvc.perform(get("/check").param("nickname", NICKNAME).session(session))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("status").value(true))
+                    .andExpect(jsonPath("message").value(SIGN_UP_AVAILABLE_NICKNAME))
+                    .andDo(print());
+        }
         
-        mvc.perform(get("/check").param("nickname", NICKNAME).session(session))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("status").value(true))
-                .andExpect(jsonPath("message").value(SIGN_UP_AVAILABLE_NICKNAME))
-                .andDo(print());
+        @DisplayName("사용 불가")
+        @Test
+        void duplicate_check_nickname_using() throws Exception {
+            MockHttpSession session = new MockHttpSession();
+            String sessionId = session.getId();
+            when(signupService.availableNickname(NICKNAME, sessionId)).thenReturn(false);
+            
+            mvc.perform(get("/check").param("nickname", NICKNAME)
+                            .session(session))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("status").value(false))
+                    .andExpect(jsonPath("message").value(SIGN_UP_UNAVAILABLE_NICKNAME))
+                    .andDo(print());
+            
+            verify(signupService, times(0)).availableEmail(EMAIL, sessionId);
+            verify(signupService, times(1)).availableNickname(NICKNAME, sessionId);
+        }
+        
+        @DisplayName("유효한 형식이 아님")
+        @Test
+        void duplicate_check_nickname_valid_exception() throws Exception {
+            mvc.perform(get("/check").param("nickname", ""))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value(false))
+                    .andExpect(jsonPath("$.message").value(VALID_EXCEPTION))
+                    .andExpect(jsonPath("$.result.[0].field").value("nickname"))
+                    .andExpect(jsonPath("$.result.[0].message").value(VALID_NICKNAME_EXCEPTION_MESSAGE))
+                    .andDo(print());
+            
+            verify(signupService, times(0)).availableEmail(anyString(), anyString());
+            verify(signupService, times(0)).availableNickname(anyString(), anyString());
+        }
+        
     }
     
-    @DisplayName("닉네임 중복 확인 - 사용 불가")
-    @Test
-    void duplicate_check_nickname_using() throws Exception {
-        MockHttpSession session = new MockHttpSession();
-        String sessionId = session.getId();
-        when(signupService.availableNickname(NICKNAME, sessionId)).thenReturn(false);
+    @DisplayName("이메일 중복확인")
+    @Nested
+    class DuplicateEmailTest {
         
-        mvc.perform(get("/check").param("nickname", NICKNAME)
-                        .session(session))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("status").value(false))
-                .andExpect(jsonPath("message").value(SIGN_UP_UNAVAILABLE_NICKNAME))
-                .andDo(print());
+        @DisplayName("사용 가능")
+        @Test
+        void duplicate_check_email() throws Exception {
+            when(signupService.availableEmail(anyString(), anyString())).thenReturn(true);
+            
+            mvc.perform(get("/check").param("email", EMAIL))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("status").value(true))
+                    .andExpect(jsonPath("message").value(SIGN_UP_AVAILABLE_EMAIL))
+                    .andDo(print());
+            
+            verify(signupService, times(1)).availableEmail(anyString(), anyString());
+            verify(signupService, times(0)).availableNickname(anyString(), anyString());
+        }
         
-        verify(signupService, times(0)).availableEmail(EMAIL, sessionId);
-        verify(signupService, times(1)).availableNickname(NICKNAME, sessionId);
+        @DisplayName("사용 불가")
+        @Test
+        void duplicate_check_email_fail() throws Exception {
+            when(signupService.availableEmail(anyString(), anyString())).thenReturn(false);
+            
+            mvc.perform(get("/check").param("email", EMAIL))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("status").value(false))
+                    .andExpect(jsonPath("message").value(SIGN_UP_UNAVAILABLE_EMAIL))
+                    .andDo(print());
+            
+            verify(signupService, times(1)).availableEmail(anyString(), anyString());
+            verify(signupService, times(0)).availableNickname(anyString(), anyString());
+        }
+        
+        @DisplayName("유효한 형식이 아님 1. 공백 입력")
+        @Test
+        void duplicate_check_email_valid_exception_blank() throws Exception {
+            mvc.perform(get("/check").param("email", ""))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value(false))
+                    .andExpect(jsonPath("$.message").value(VALID_EXCEPTION))
+                    .andExpect(jsonPath("$.result.[0].field").value("email"))
+                    .andExpect(jsonPath("$.result.[0].message").value(EMAIL_VALID_EXCEPTION_MESSAGE))
+                    .andDo(print());
+            
+            verify(signupService, times(0)).availableEmail(anyString(), anyString());
+            verify(signupService, times(0)).availableNickname(anyString(), anyString());
+        }
+        
+        @DisplayName("유효한 형식이 아님 2. 형식 오류")
+        @Test
+        void duplicate_check_email_valid_exception_format() throws Exception {
+            mvc.perform(get("/check").param("email", "오호@."))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value(false))
+                    .andExpect(jsonPath("$.message").value(VALID_EXCEPTION))
+                    .andExpect(jsonPath("$.result.[0].field").value("email"))
+                    .andExpect(jsonPath("$.result.[0].message").value(EMAIL_VALID_EXCEPTION_MESSAGE))
+                    .andDo(print());
+            
+            verify(signupService, times(0)).availableEmail(anyString(), anyString());
+            verify(signupService, times(0)).availableNickname(anyString(), anyString());
+        }
     }
     
-    @DisplayName("닉네임 중복 확인 - 유효한 형식이 아님")
-    @Test
-    void duplicate_check_nickname_valid_exception() throws Exception {
-        mvc.perform(get("/check").param("nickname", ""))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(false))
-                .andExpect(jsonPath("$.message").value(VALID_EXCEPTION))
-                .andExpect(jsonPath("$.result.[0].field").value("nickname"))
-                .andExpect(jsonPath("$.result.[0].message").value(VALID_NICKNAME_EXCEPTION_MESSAGE))
-                .andDo(print());
+    @Nested
+    @DisplayName("인증 코드 메일 발송")
+    class SendEmailAuthCodeTest {
         
-        verify(signupService, times(0)).availableEmail(anyString(), anyString());
-        verify(signupService, times(0)).availableNickname(anyString(), anyString());
-    }
-    
-    @DisplayName("이메일 중복 확인 - 사용 가능")
-    @Test
-    void duplicate_check_email() throws Exception {
-        when(signupService.availableEmail(anyString(), anyString())).thenReturn(true);
+        @DisplayName("fail : request body is empty")
+        @Test
+        void send_email_fail_not_input_email() throws Exception {
+            // when-then
+            mvc.perform(post("/check/auth")
+                            .contentType(APPLICATION_JSON))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value(false))
+                    .andExpect(jsonPath("$.message").value(REQUIRED_REQUEST_BODY))
+                    .andDo(print());
+            
+            verify(signupService, times(0)).sendEmailAuthCode("", null);
+        }
         
-        mvc.perform(get("/check").param("email", EMAIL))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("status").value(true))
-                .andExpect(jsonPath("message").value(SIGN_UP_AVAILABLE_EMAIL))
-                .andDo(print());
+        @DisplayName("fail : 이메일 입력 안됨")
+        @Test
+        void send_email_fail_email_valid_exception_null() throws Exception {
+            // given
+            EmailAuthCodeRequest given = EmailAuthCodeRequest.of(null);
+            
+            // when-then
+            mvc.perform(post("/check/auth")
+                            .contentType(APPLICATION_JSON)
+                            .content(mapper.writeValueAsString(given)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value(false))
+                    .andExpect(jsonPath("$.message").value(VALID_EXCEPTION))
+                    .andExpect(jsonPath("$.result.[0].field").value("email"))
+                    .andExpect(jsonPath("$.result.[0].message").value(EMAIL_VALID_EXCEPTION_MESSAGE))
+                    .andDo(print());
+            
+            verify(signupService, times(0)).sendEmailAuthCode("", given);
+        }
         
-        verify(signupService, times(1)).availableEmail(anyString(), anyString());
-        verify(signupService, times(0)).availableNickname(anyString(), anyString());
-    }
-    
-    @DisplayName("이메일 중복 확인 - 사용 불가")
-    @Test
-    void duplicate_check_email_fail() throws Exception {
-        when(signupService.availableEmail(anyString(), anyString())).thenReturn(false);
+        @DisplayName("fail : 이메일 형식 오류")
+        @Test
+        void send_email_fail_email_valid_exception() throws Exception {
+            // given
+            EmailAuthCodeRequest given = EmailAuthCodeRequest.of("test@asd");
+            
+            // when-then
+            mvc.perform(post("/check/auth")
+                            .contentType(APPLICATION_JSON)
+                            .content(mapper.writeValueAsString(given)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value(false))
+                    .andExpect(jsonPath("$.message").value(VALID_EXCEPTION))
+                    .andExpect(jsonPath("$.result.[0].field").value("email"))
+                    .andExpect(jsonPath("$.result.[0].message").value(EMAIL_VALID_EXCEPTION_MESSAGE))
+                    .andDo(print());
+            
+            verify(signupService, times(0)).sendEmailAuthCode("", given);
+        }
         
-        mvc.perform(get("/check").param("email", EMAIL))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("status").value(false))
-                .andExpect(jsonPath("message").value(SIGN_UP_UNAVAILABLE_EMAIL))
-                .andDo(print());
+        @DisplayName("fail : 이메일 중복검사 안함")
+        @Test
+        void send_email_fail_email_duplicate_check_pass() throws Exception {
+            // given
+            MockHttpSession session = new MockHttpSession();
+            String sessionId = session.getId();
+            
+            EmailAuthCodeRequest given = EmailAuthCodeRequest.of(EMAIL);
+            
+            doThrow(new MailAuthException(REQUIRE_MAIL_DUPLICATE_CHECK))
+                    .when(signupService).sendEmailAuthCode(sessionId, given);
+            
+            // when-then
+            mvc.perform(post("/check/auth")
+                            .contentType(APPLICATION_JSON)
+                            .content(mapper.writeValueAsString(given))
+                            .session(session))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value(false))
+                    .andExpect(jsonPath("$.message").value(REQUIRE_MAIL_DUPLICATE_CHECK))
+                    .andDo(print());
+            
+            verify(signupService, times(1)).sendEmailAuthCode(sessionId, given);
+        }
         
-        verify(signupService, times(1)).availableEmail(anyString(), anyString());
-        verify(signupService, times(0)).availableNickname(anyString(), anyString());
-    }
-    
-    @DisplayName("이메일 중복 확인 - 유효한 형식이 아님 1. 공백 입력")
-    @Test
-    void duplicate_check_email_valid_exception_blank() throws Exception {
-        mvc.perform(get("/check").param("email", ""))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(false))
-                .andExpect(jsonPath("$.message").value(VALID_EXCEPTION))
-                .andExpect(jsonPath("$.result.[0].field").value("email"))
-                .andExpect(jsonPath("$.result.[0].message").value(EMAIL_VALID_EXCEPTION_MESSAGE))
-                .andDo(print());
-        
-        verify(signupService, times(0)).availableEmail(anyString(), anyString());
-        verify(signupService, times(0)).availableNickname(anyString(), anyString());
-    }
-    
-    @DisplayName("이메일 중복 확인 - 유효한 형식이 아님 1. 형식 오류")
-    @Test
-    void duplicate_check_email_valid_exception_format() throws Exception {
-        mvc.perform(get("/check").param("email", "오호@."))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(false))
-                .andExpect(jsonPath("$.message").value(VALID_EXCEPTION))
-                .andExpect(jsonPath("$.result.[0].field").value("email"))
-                .andExpect(jsonPath("$.result.[0].message").value(EMAIL_VALID_EXCEPTION_MESSAGE))
-                .andDo(print());
-        
-        verify(signupService, times(0)).availableEmail(anyString(), anyString());
-        verify(signupService, times(0)).availableNickname(anyString(), anyString());
-    }
-    
-    @DisplayName("인증 코드 메일 발송 - request body is empty")
-    @Test
-    void send_email_fail_not_input_email() throws Exception {
-        // when-then
-        mvc.perform(post("/check/auth")
-                        .contentType(APPLICATION_JSON))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(false))
-                .andExpect(jsonPath("$.message").value(REQUIRED_REQUEST_BODY))
-                .andDo(print());
-        
-        verify(signupService, times(0)).sendEmailAuthCode("", null);
-    }
-    
-    @DisplayName("인증 코드 메일 발송 - 이메일 입력 안됨")
-    @Test
-    void send_email_fail_email_valid_exception_null() throws Exception {
-        // given
-        EmailAuthCodeRequest given = EmailAuthCodeRequest.of(null);
-        
-        // when-then
-        mvc.perform(post("/check/auth")
-                        .contentType(APPLICATION_JSON)
-                        .content(mapper.writeValueAsString(given)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(false))
-                .andExpect(jsonPath("$.message").value(VALID_EXCEPTION))
-                .andExpect(jsonPath("$.result.[0].field").value("email"))
-                .andExpect(jsonPath("$.result.[0].message").value(EMAIL_VALID_EXCEPTION_MESSAGE))
-                .andDo(print());
-        
-        verify(signupService, times(0)).sendEmailAuthCode("", given);
-    }
-    
-    @DisplayName("인증 코드 메일 발송 - 이메일 형식 오류")
-    @Test
-    void send_email_fail_email_valid_exception() throws Exception {
-        // given
-        EmailAuthCodeRequest given = EmailAuthCodeRequest.of("test@asd");
-        
-        // when-then
-        mvc.perform(post("/check/auth")
-                        .contentType(APPLICATION_JSON)
-                        .content(mapper.writeValueAsString(given)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(false))
-                .andExpect(jsonPath("$.message").value(VALID_EXCEPTION))
-                .andExpect(jsonPath("$.result.[0].field").value("email"))
-                .andExpect(jsonPath("$.result.[0].message").value(EMAIL_VALID_EXCEPTION_MESSAGE))
-                .andDo(print());
-        
-        verify(signupService, times(0)).sendEmailAuthCode("", given);
-    }
-    
-    @DisplayName("인증 코드 메일 발송 - fail : 이메일 중복검사 안함")
-    @Test
-    void send_email_fail_email_duplicate_check_pass() throws Exception {
-        // given
-        MockHttpSession session = new MockHttpSession();
-        String sessionId = session.getId();
-        
-        EmailAuthCodeRequest given = EmailAuthCodeRequest.of(EMAIL);
-        
-        doThrow(new MailAuthException(REQUIRE_MAIL_DUPLICATE_CHECK))
-                .when(signupService).sendEmailAuthCode(sessionId, given);
-        
-        // when-then
-        mvc.perform(post("/check/auth")
-                        .contentType(APPLICATION_JSON)
-                        .content(mapper.writeValueAsString(given))
-                        .session(session))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(false))
-                .andExpect(jsonPath("$.message").value(REQUIRE_MAIL_DUPLICATE_CHECK))
-                .andDo(print());
-        
-        verify(signupService, times(1)).sendEmailAuthCode(sessionId, given);
-    }
-    
-    @DisplayName("인증 코드 메일 발송 - success")
-    @Test
-    void send_email_success() throws Exception {
-        // given
-        MockHttpSession session = new MockHttpSession();
-        String sessionId = session.getId();
-        
-        EmailAuthCodeRequest given = EmailAuthCodeRequest.of(EMAIL);
-        
-        doNothing().when(signupService).sendEmailAuthCode(sessionId, given);
-        
-        // when-then
-        mvc.perform(post("/check/auth")
-                        .contentType(APPLICATION_JSON)
-                        .content(mapper.writeValueAsString(given))
-                        .session(session))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value(true))
-                .andExpect(jsonPath("$.message").value(SEND_EMAIL_AUTH_CODE))
-                .andDo(print());
-        
-        verify(signupService, times(1)).sendEmailAuthCode(sessionId, given);
+        @DisplayName("success")
+        @Test
+        void send_email_success() throws Exception {
+            // given
+            MockHttpSession session = new MockHttpSession();
+            String sessionId = session.getId();
+            
+            EmailAuthCodeRequest given = EmailAuthCodeRequest.of(EMAIL);
+            
+            doNothing().when(signupService).sendEmailAuthCode(sessionId, given);
+            
+            // when-then
+            mvc.perform(post("/check/auth")
+                            .contentType(APPLICATION_JSON)
+                            .content(mapper.writeValueAsString(given))
+                            .session(session))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(true))
+                    .andExpect(jsonPath("$.message").value(SEND_EMAIL_AUTH_CODE))
+                    .andDo(print());
+            
+            verify(signupService, times(1)).sendEmailAuthCode(sessionId, given);
+        }
     }
 }

--- a/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/controller/CheckControllerTest.java
+++ b/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/controller/CheckControllerTest.java
@@ -16,8 +16,7 @@ import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
-import static kim.zhyun.serveruser.data.message.ExceptionMessage.REQUIRED_REQUEST_BODY;
-import static kim.zhyun.serveruser.data.message.ExceptionMessage.REQUIRE_MAIL_DUPLICATE_CHECK;
+import static kim.zhyun.serveruser.data.message.ExceptionMessage.*;
 import static kim.zhyun.serveruser.data.message.ResponseMessage.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.*;
@@ -55,7 +54,7 @@ class CheckControllerTest {
         mvc.perform(get("/check"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("status").value(false))
-                .andExpect(jsonPath("message").value(SIGN_UP_CHECK_VALUE_IS_EMPTY.getMessage()))
+                .andExpect(jsonPath("message").value(SIGN_UP_CHECK_VALUE_IS_EMPTY))
                 .andDo(print());
         
         verify(signupService, times(0)).availableEmail(anyString(), anyString());
@@ -72,7 +71,7 @@ class CheckControllerTest {
         mvc.perform(get("/check").param("nickname", NICKNAME).session(session))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("status").value(true))
-                .andExpect(jsonPath("message").value(SIGN_UP_AVAILABLE_NICKNAME.getMessage()))
+                .andExpect(jsonPath("message").value(SIGN_UP_AVAILABLE_NICKNAME))
                 .andDo(print());
     }
     
@@ -87,7 +86,7 @@ class CheckControllerTest {
                         .session(session))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("status").value(false))
-                .andExpect(jsonPath("message").value(SIGN_UP_UNAVAILABLE_NICKNAME.getMessage()))
+                .andExpect(jsonPath("message").value(SIGN_UP_UNAVAILABLE_NICKNAME))
                 .andDo(print());
         
         verify(signupService, times(0)).availableEmail(EMAIL, sessionId);
@@ -100,9 +99,9 @@ class CheckControllerTest {
         mvc.perform(get("/check").param("nickname", ""))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(false))
-                .andExpect(jsonPath("$.message").value(VALID_EXCEPTION.getMessage()))
+                .andExpect(jsonPath("$.message").value(VALID_EXCEPTION))
                 .andExpect(jsonPath("$.result.[0].field").value("nickname"))
-                .andExpect(jsonPath("$.result.[0].message").value("1글자 이상, 6글자 이하로 입력해주세요."))
+                .andExpect(jsonPath("$.result.[0].message").value(VALID_NICKNAME_EXCEPTION_MESSAGE))
                 .andDo(print());
         
         verify(signupService, times(0)).availableEmail(anyString(), anyString());
@@ -117,7 +116,7 @@ class CheckControllerTest {
         mvc.perform(get("/check").param("email", EMAIL))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("status").value(true))
-                .andExpect(jsonPath("message").value(SIGN_UP_AVAILABLE_EMAIL.getMessage()))
+                .andExpect(jsonPath("message").value(SIGN_UP_AVAILABLE_EMAIL))
                 .andDo(print());
         
         verify(signupService, times(1)).availableEmail(anyString(), anyString());
@@ -132,7 +131,7 @@ class CheckControllerTest {
         mvc.perform(get("/check").param("email", EMAIL))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("status").value(false))
-                .andExpect(jsonPath("message").value(SIGN_UP_UNAVAILABLE_EMAIL.getMessage()))
+                .andExpect(jsonPath("message").value(SIGN_UP_UNAVAILABLE_EMAIL))
                 .andDo(print());
         
         verify(signupService, times(1)).availableEmail(anyString(), anyString());
@@ -145,7 +144,7 @@ class CheckControllerTest {
         mvc.perform(get("/check").param("email", ""))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(false))
-                .andExpect(jsonPath("$.message").value(VALID_EXCEPTION.getMessage()))
+                .andExpect(jsonPath("$.message").value(VALID_EXCEPTION))
                 .andExpect(jsonPath("$.result.[0].field").value("email"))
                 .andExpect(jsonPath("$.result.[0].message").value(EMAIL_VALID_EXCEPTION_MESSAGE))
                 .andDo(print());
@@ -160,7 +159,7 @@ class CheckControllerTest {
         mvc.perform(get("/check").param("email", "오호@."))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(false))
-                .andExpect(jsonPath("$.message").value(VALID_EXCEPTION.getMessage()))
+                .andExpect(jsonPath("$.message").value(VALID_EXCEPTION))
                 .andExpect(jsonPath("$.result.[0].field").value("email"))
                 .andExpect(jsonPath("$.result.[0].message").value(EMAIL_VALID_EXCEPTION_MESSAGE))
                 .andDo(print());
@@ -177,7 +176,7 @@ class CheckControllerTest {
                         .contentType(APPLICATION_JSON))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(false))
-                .andExpect(jsonPath("$.message").value(REQUIRED_REQUEST_BODY.getMessage()))
+                .andExpect(jsonPath("$.message").value(REQUIRED_REQUEST_BODY))
                 .andDo(print());
         
         verify(signupService, times(0)).sendEmailAuthCode("", null);
@@ -195,7 +194,7 @@ class CheckControllerTest {
                         .content(mapper.writeValueAsString(given)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(false))
-                .andExpect(jsonPath("$.message").value(VALID_EXCEPTION.getMessage()))
+                .andExpect(jsonPath("$.message").value(VALID_EXCEPTION))
                 .andExpect(jsonPath("$.result.[0].field").value("email"))
                 .andExpect(jsonPath("$.result.[0].message").value(EMAIL_VALID_EXCEPTION_MESSAGE))
                 .andDo(print());
@@ -215,7 +214,7 @@ class CheckControllerTest {
                         .content(mapper.writeValueAsString(given)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(false))
-                .andExpect(jsonPath("$.message").value(VALID_EXCEPTION.getMessage()))
+                .andExpect(jsonPath("$.message").value(VALID_EXCEPTION))
                 .andExpect(jsonPath("$.result.[0].field").value("email"))
                 .andExpect(jsonPath("$.result.[0].message").value(EMAIL_VALID_EXCEPTION_MESSAGE))
                 .andDo(print());
@@ -242,7 +241,7 @@ class CheckControllerTest {
                         .session(session))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(false))
-                .andExpect(jsonPath("$.message").value(REQUIRE_MAIL_DUPLICATE_CHECK.getMessage()))
+                .andExpect(jsonPath("$.message").value(REQUIRE_MAIL_DUPLICATE_CHECK))
                 .andDo(print());
         
         verify(signupService, times(1)).sendEmailAuthCode(sessionId, given);
@@ -266,7 +265,7 @@ class CheckControllerTest {
                         .session(session))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value(true))
-                .andExpect(jsonPath("$.message").value(SEND_EMAIL_AUTH_CODE.getMessage()))
+                .andExpect(jsonPath("$.message").value(SEND_EMAIL_AUTH_CODE))
                 .andDo(print());
         
         verify(signupService, times(1)).sendEmailAuthCode(sessionId, given);

--- a/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/controller/CheckControllerTest.java
+++ b/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/controller/CheckControllerTest.java
@@ -72,7 +72,7 @@ class CheckControllerTest {
         
         mvc.perform(get("/check").param("nickname", NICKNAME))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("status").value(true))
+                .andExpect(jsonPath("status").value(false))
                 .andExpect(jsonPath("message").value(SIGN_UP_UNAVAILABLE_NICKNAME.getMessage()))
                 .andDo(print());
         
@@ -117,7 +117,7 @@ class CheckControllerTest {
         
         mvc.perform(get("/check").param("email", EMAIL))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("status").value(true))
+                .andExpect(jsonPath("status").value(false))
                 .andExpect(jsonPath("message").value(SIGN_UP_UNAVAILABLE_EMAIL.getMessage()))
                 .andDo(print());
         

--- a/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/interceptor/ConnectionInterceptorTest.java
+++ b/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/interceptor/ConnectionInterceptorTest.java
@@ -87,7 +87,6 @@ class ConnectionInterceptorTest {
     
     @Nested
     @DisplayName("SessionService Call Test")
-    @AutoConfigureMockMvc
     class ConnectedSessionTest {
         
         @InjectMocks    private ConnectionInterceptor connectionInterceptor;

--- a/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/interceptor/ConnectionInterceptorTest.java
+++ b/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/interceptor/ConnectionInterceptorTest.java
@@ -2,7 +2,7 @@ package kim.zhyun.serveruser.interceptor;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import kim.zhyun.serveruser.entity.SessionUser;
+import kim.zhyun.serveruser.data.entity.SessionUser;
 import kim.zhyun.serveruser.service.SessionUserService;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;

--- a/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/interceptor/DisconnectionInterceptorTest.java
+++ b/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/interceptor/DisconnectionInterceptorTest.java
@@ -106,7 +106,6 @@ class DisconnectionInterceptorTest {
     
     @Nested
     @DisplayName("SessionService Call Test")
-    @AutoConfigureMockMvc
     class DisconnectedSessionTest {
         
         @InjectMocks    private ConnectionInterceptor connectionInterceptor;

--- a/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/interceptor/DisconnectionInterceptorTest.java
+++ b/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/interceptor/DisconnectionInterceptorTest.java
@@ -3,7 +3,7 @@ package kim.zhyun.serveruser.interceptor;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import kim.zhyun.serveruser.data.NicknameDto;
-import kim.zhyun.serveruser.entity.SessionUser;
+import kim.zhyun.serveruser.data.entity.SessionUser;
 import kim.zhyun.serveruser.service.NicknameReserveService;
 import kim.zhyun.serveruser.service.SessionUserService;
 import lombok.extern.slf4j.Slf4j;

--- a/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/repository/EmailAuthStorageTest.java
+++ b/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/repository/EmailAuthStorageTest.java
@@ -6,10 +6,7 @@ import kim.zhyun.serveruser.repository.container.RedisTestContainer;
 import kim.zhyun.serveruser.service.EmailService;
 import kim.zhyun.serveruser.service.SessionUserService;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,6 +16,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import static org.junit.jupiter.api.Assertions.*;
 
 @Slf4j
+@Order(0)
 @DisplayName("Redis Email Auth Storage 테스트")
 @ExtendWith(RedisTestContainer.class)
 @SpringBootTest

--- a/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/repository/EmailAuthStorageTest.java
+++ b/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/repository/EmailAuthStorageTest.java
@@ -1,7 +1,7 @@
 package kim.zhyun.serveruser.repository;
 
 import kim.zhyun.serveruser.data.EmailAuthDto;
-import kim.zhyun.serveruser.entity.SessionUser;
+import kim.zhyun.serveruser.data.entity.SessionUser;
 import kim.zhyun.serveruser.repository.container.RedisTestContainer;
 import kim.zhyun.serveruser.service.EmailService;
 import kim.zhyun.serveruser.service.SessionUserService;

--- a/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/repository/NicknameStorageTest.java
+++ b/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/repository/NicknameStorageTest.java
@@ -6,10 +6,7 @@ import kim.zhyun.serveruser.repository.container.RedisTestContainer;
 import kim.zhyun.serveruser.service.NicknameReserveService;
 import kim.zhyun.serveruser.service.SessionUserService;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -19,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Slf4j
+@Order(0)
 @DisplayName("Redis Nickname Storage 테스트")
 @ExtendWith(RedisTestContainer.class)
 @SpringBootTest

--- a/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/repository/NicknameStorageTest.java
+++ b/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/repository/NicknameStorageTest.java
@@ -1,7 +1,7 @@
 package kim.zhyun.serveruser.repository;
 
 import kim.zhyun.serveruser.data.NicknameDto;
-import kim.zhyun.serveruser.entity.SessionUser;
+import kim.zhyun.serveruser.data.entity.SessionUser;
 import kim.zhyun.serveruser.repository.container.RedisTestContainer;
 import kim.zhyun.serveruser.service.NicknameReserveService;
 import kim.zhyun.serveruser.service.SessionUserService;

--- a/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/repository/RoleRepositoryTest.java
+++ b/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/repository/RoleRepositoryTest.java
@@ -2,7 +2,7 @@ package kim.zhyun.serveruser.repository;
 
 import kim.zhyun.serveruser.config.JpaConfig;
 import kim.zhyun.serveruser.data.type.RoleType;
-import kim.zhyun.serveruser.entity.Role;
+import kim.zhyun.serveruser.data.entity.Role;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/repository/SessionUserRepositoryTest.java
+++ b/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/repository/SessionUserRepositoryTest.java
@@ -3,18 +3,19 @@ package kim.zhyun.serveruser.repository;
 import kim.zhyun.serveruser.data.entity.SessionUser;
 import kim.zhyun.serveruser.repository.container.RedisTestContainer;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.testcontainers.shaded.org.checkerframework.checker.index.qual.IndexOrHigh;
 
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 @Slf4j
+@Order(0)
 @DisplayName("Redis Session Id Storage 테스트")
 @ExtendWith(RedisTestContainer.class)
 @SpringBootTest

--- a/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/repository/SessionUserRepositoryTest.java
+++ b/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/repository/SessionUserRepositoryTest.java
@@ -1,6 +1,6 @@
 package kim.zhyun.serveruser.repository;
 
-import kim.zhyun.serveruser.entity.SessionUser;
+import kim.zhyun.serveruser.data.entity.SessionUser;
 import kim.zhyun.serveruser.repository.container.RedisTestContainer;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;

--- a/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/repository/container/RedisTestContainer.java
+++ b/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/repository/container/RedisTestContainer.java
@@ -3,13 +3,18 @@ package kim.zhyun.serveruser.repository.container;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 
+@Testcontainers
 public class RedisTestContainer implements BeforeAllCallback {
     
     private static final String REDIS_IMAGE = "redis";
     private static final int REDIS_PORT = 6379;
+    
+    @Container
     private GenericContainer redis;
     
     @Override

--- a/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/service/impl/SignUpServiceImplTest.java
+++ b/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/service/impl/SignUpServiceImplTest.java
@@ -1,7 +1,7 @@
 package kim.zhyun.serveruser.service.impl;
 
 import kim.zhyun.serveruser.data.NicknameDto;
-import kim.zhyun.serveruser.entity.SessionUser;
+import kim.zhyun.serveruser.data.entity.SessionUser;
 import kim.zhyun.serveruser.repository.UserRepository;
 import kim.zhyun.serveruser.repository.container.RedisTestContainer;
 import kim.zhyun.serveruser.service.NicknameReserveService;

--- a/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/service/impl/SignUpServiceImplTest.java
+++ b/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/service/impl/SignUpServiceImplTest.java
@@ -17,10 +17,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
-/**
- * 서비스 로직 검증 방법
- * 1. mock - inject mock , verify 확인
- */
 @Slf4j
 @ExtendWith(RedisTestContainer.class)
 @SpringBootTest

--- a/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/service/impl/SignUpServiceImplTest.java
+++ b/simpleBoard02/server-b-user/src/test/java/kim/zhyun/serveruser/service/impl/SignUpServiceImplTest.java
@@ -10,8 +10,8 @@ import kim.zhyun.serveruser.service.EmailService;
 import kim.zhyun.serveruser.service.NicknameReserveService;
 import kim.zhyun.serveruser.service.SessionUserService;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.Assert;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -37,159 +37,174 @@ class SignUpServiceImplTest {
     @Mock        SessionUserService sessionUserService;
     @Mock        EmailService emailService;
     
-    @DisplayName("이메일 사용 불가 - 사용중인 이메일")
-    @Test
-    void available_email_true() {
-        // given
-        when(userRepository.existsByEmailIgnoreCase(EMAIL)).thenReturn(true);
+    @Nested
+    @DisplayName("이메일 중복 확인")
+    class DuplicateEmail {
         
-        // when
-        boolean availableEmail = signupService.availableEmail(EMAIL, SESSION_ID);
+        @DisplayName("사용 불가 - 사용중인 이메일")
+        @Test
+        void available_email_true() {
+            // given
+            when(userRepository.existsByEmailIgnoreCase(EMAIL)).thenReturn(true);
+            
+            // when
+            boolean availableEmail = signupService.availableEmail(EMAIL, SESSION_ID);
+            
+            // then
+            verify(userRepository, times(1)).existsByEmailIgnoreCase(EMAIL);
+            verify(sessionUserService, times(0)).findById(SESSION_ID);
+            verify(sessionUserService, times(0)).save(null);
+            
+            assertThat(availableEmail).isFalse();
+        }
         
-        // then
-        verify(userRepository, times(1)).existsByEmailIgnoreCase(EMAIL);
-        verify(sessionUserService, times(0)).findById(SESSION_ID);
-        verify(sessionUserService, times(0)).save(null);
-        
-        assertThat(availableEmail).isFalse();
+        @DisplayName("사용 가능")
+        @Test
+        void available_email_false() {
+            // given
+            SessionUser sessionUser = SessionUser.builder()
+                    .sessionId(SESSION_ID).build();
+            
+            when(userRepository.existsByEmailIgnoreCase(EMAIL)).thenReturn(false);
+            when(sessionUserService.findById(SESSION_ID)).thenReturn(sessionUser);
+            
+            // when
+            boolean availableEmail = signupService.availableEmail(EMAIL, SESSION_ID);
+            
+            // then
+            sessionUser.setEmail(EMAIL);
+            
+            verify(userRepository, times(1)).existsByEmailIgnoreCase(EMAIL);
+            verify(sessionUserService, times(1)).findById(SESSION_ID);
+            verify(sessionUserService, times(1)).save(sessionUser);
+            
+            assertThat(availableEmail).isTrue();
+        }
     }
     
-    @DisplayName("이메일 사용 가능")
-    @Test
-    void available_email_false() {
-        // given
-        SessionUser sessionUser = SessionUser.builder()
-                .sessionId(SESSION_ID).build();
+    @DisplayName("닉네임 중복 확인")
+    @Nested
+    class NicknameDuplicate {
         
-        when(userRepository.existsByEmailIgnoreCase(EMAIL)).thenReturn(false);
-        when(sessionUserService.findById(SESSION_ID)).thenReturn(sessionUser);
-
-        // when
-        boolean availableEmail = signupService.availableEmail(EMAIL, SESSION_ID);
-
-        // then
-        sessionUser.setEmail(EMAIL);
+        @DisplayName("사용 불가 - 사용중인 닉네임")
+        @Test
+        void available_nickname_false_cause_using() {
+            // given
+            when(userRepository.existsByNicknameIgnoreCase(NICKNAME)).thenReturn(true);
+            
+            // when
+            boolean availableNickname = signupService.availableNickname(NICKNAME, SESSION_ID);
+            
+            // then
+            verify(userRepository, times(1)).existsByNicknameIgnoreCase(NICKNAME);
+            
+            verify(nicknameReserveService, times(0)).existNickname(null);
+            verify(nicknameReserveService, times(0)).saveNickname(null);
+            verify(sessionUserService, times(0)).findById(SESSION_ID);
+            verify(sessionUserService, times(0)).save(null);
+            
+            assertThat(availableNickname).isFalse();
+        }
         
-        verify(userRepository, times(1)).existsByEmailIgnoreCase(EMAIL);
-        verify(sessionUserService, times(1)).findById(SESSION_ID);
-        verify(sessionUserService, times(1)).save(sessionUser);
+        @DisplayName("사용 불가 - 예약 된 닉네임")
+        @Test
+        void available_nickname_false_cause_reserved() {
+            // given
+            NicknameDto nicknameInfo = NicknameDto.builder()
+                    .nickname(NICKNAME)
+                    .sessionId(SESSION_ID).build();
+            
+            when(userRepository.existsByNicknameIgnoreCase(NICKNAME)).thenReturn(false);
+            when(nicknameReserveService.existNickname(nicknameInfo)).thenReturn(true);
+            
+            // when
+            boolean availableNickname = signupService.availableNickname(NICKNAME, SESSION_ID);
+            
+            // then
+            verify(userRepository, times(1)).existsByNicknameIgnoreCase(NICKNAME);
+            verify(nicknameReserveService, times(1)).existNickname(nicknameInfo);
+            
+            verify(nicknameReserveService, times(0)).saveNickname(nicknameInfo);
+            verify(sessionUserService, times(0)).findById(SESSION_ID);
+            verify(sessionUserService, times(0)).save(null);
+            
+            assertThat(availableNickname).isFalse();
+        }
         
-        assertThat(availableEmail).isTrue();
+        @DisplayName("사용 가능")
+        @Test
+        void available_nickname_true() {
+            // given
+            NicknameDto nicknameInfo = NicknameDto.builder()
+                    .nickname(NICKNAME)
+                    .sessionId(SESSION_ID).build();
+            
+            SessionUser sessionUser = SessionUser.builder()
+                    .sessionId(SESSION_ID).build();
+            
+            when(userRepository.existsByNicknameIgnoreCase(NICKNAME)).thenReturn(false);
+            when(nicknameReserveService.existNickname(nicknameInfo)).thenReturn(false);
+            when(sessionUserService.findById(SESSION_ID)).thenReturn(sessionUser);
+            
+            // when
+            boolean availableNickname = signupService.availableNickname(NICKNAME, SESSION_ID);
+            
+            // then
+            sessionUser.setNickname(NICKNAME);
+            
+            verify(userRepository, times(1)).existsByNicknameIgnoreCase(NICKNAME);
+            verify(nicknameReserveService, times(1)).existNickname(nicknameInfo);
+            verify(nicknameReserveService, times(1)).saveNickname(nicknameInfo);
+            verify(sessionUserService, times(1)).findById(SESSION_ID);
+            verify(sessionUserService, times(1)).save(sessionUser);
+            
+            assertThat(availableNickname).isTrue();
+        }
     }
     
-    @DisplayName("사용 불가 - 사용중인 닉네임")
-    @Test
-    void available_nickname_false_cause_using() {
-        // given
-        when(userRepository.existsByNicknameIgnoreCase(NICKNAME)).thenReturn(true);
+    @DisplayName("인증 코드 메일 발송")
+    @Nested
+    class SendEmailAuthCode {
         
-        // when
-        boolean availableNickname = signupService.availableNickname(NICKNAME, SESSION_ID);
+        @DisplayName("실패 : 중복검사 하지 않은 email")
+        @Test
+        void send_email_auth_code_fail() {
+            // given
+            SessionUser sessionUser = SessionUser.builder()
+                    .sessionId(SESSION_ID).build();
+            EmailAuthCodeRequest requestInfo = EmailAuthCodeRequest.of(EMAIL);
+            
+            // when
+            when(sessionUserService.findById(SESSION_ID)).thenReturn(sessionUser);
+            
+            // then
+            assertThrows(REQUIRE_MAIL_DUPLICATE_CHECK,
+                    MailAuthException.class,
+                    () -> signupService.sendEmailAuthCode(SESSION_ID, requestInfo));
+            
+            verify(sessionUserService, times(1)).findById(SESSION_ID);
+            verify(emailService, times(0)).sendEmailAuthCode(null);
+        }
         
-        // then
-        verify(userRepository, times(1)).existsByNicknameIgnoreCase(NICKNAME);
-        
-        verify(nicknameReserveService, times(0)).existNickname(null);
-        verify(nicknameReserveService, times(0)).saveNickname(null);
-        verify(sessionUserService, times(0)).findById(SESSION_ID);
-        verify(sessionUserService, times(0)).save(null);
-        
-        assertThat(availableNickname).isFalse();
+        @DisplayName("성공")
+        @Test
+        void send_email_auth_code() {
+            // given
+            SessionUser sessionUser = SessionUser.builder()
+                    .sessionId(SESSION_ID)
+                    .email(EMAIL).build();
+            EmailAuthCodeRequest requestInfo = EmailAuthCodeRequest.of(EMAIL);
+            
+            // when
+            when(sessionUserService.findById(SESSION_ID)).thenReturn(sessionUser);
+            
+            signupService.sendEmailAuthCode(SESSION_ID, requestInfo);
+            
+            // then
+            verify(sessionUserService, times(1)).findById(SESSION_ID);
+            verify(emailService, times(1)).sendEmailAuthCode(requestInfo.getEmail());
+        }
     }
     
-    @DisplayName("사용 불가 - 예약 된 닉네임")
-    @Test
-    void available_nickname_false_cause_reserved() {
-        // given
-        NicknameDto nicknameInfo = NicknameDto.builder()
-                .nickname(NICKNAME)
-                .sessionId(SESSION_ID).build();
-        
-        when(userRepository.existsByNicknameIgnoreCase(NICKNAME)).thenReturn(false);
-        when(nicknameReserveService.existNickname(nicknameInfo)).thenReturn(true);
-        
-        // when
-        boolean availableNickname = signupService.availableNickname(NICKNAME, SESSION_ID);
-        
-        // then
-        verify(userRepository, times(1)).existsByNicknameIgnoreCase(NICKNAME);
-        verify(nicknameReserveService, times(1)).existNickname(nicknameInfo);
-        
-        verify(nicknameReserveService, times(0)).saveNickname(nicknameInfo);
-        verify(sessionUserService, times(0)).findById(SESSION_ID);
-        verify(sessionUserService, times(0)).save(null);
-        
-        assertThat(availableNickname).isFalse();
-    }
-    
-    @DisplayName("사용 가능")
-    @Test
-    void available_nickname_true() {
-        // given
-        NicknameDto nicknameInfo = NicknameDto.builder()
-                .nickname(NICKNAME)
-                .sessionId(SESSION_ID).build();
-        
-        SessionUser sessionUser = SessionUser.builder()
-                .sessionId(SESSION_ID).build();
-        
-        when(userRepository.existsByNicknameIgnoreCase(NICKNAME)).thenReturn(false);
-        when(nicknameReserveService.existNickname(nicknameInfo)).thenReturn(false);
-        when(sessionUserService.findById(SESSION_ID)).thenReturn(sessionUser);
-        
-        // when
-        boolean availableNickname = signupService.availableNickname(NICKNAME, SESSION_ID);
-        
-        // then
-        sessionUser.setNickname(NICKNAME);
-        
-        verify(userRepository, times(1)).existsByNicknameIgnoreCase(NICKNAME);
-        verify(nicknameReserveService, times(1)).existNickname(nicknameInfo);
-        verify(nicknameReserveService, times(1)).saveNickname(nicknameInfo);
-        verify(sessionUserService, times(1)).findById(SESSION_ID);
-        verify(sessionUserService, times(1)).save(sessionUser);
-        
-        assertThat(availableNickname).isTrue();
-    }
-    
-    
-    @DisplayName("인증 코드 메일 발송 - 실패 : 중복검사 하지 않은 email")
-    @Test
-    void send_email_auth_code_fail() {
-        // given
-        SessionUser sessionUser = SessionUser.builder()
-                .sessionId(SESSION_ID).build();
-        EmailAuthCodeRequest requestInfo = EmailAuthCodeRequest.of(EMAIL);
-        
-        // when
-        when(sessionUserService.findById(SESSION_ID)).thenReturn(sessionUser);
-        
-        // then
-        assertThrows(REQUIRE_MAIL_DUPLICATE_CHECK,
-                MailAuthException.class,
-                () -> signupService.sendEmailAuthCode(SESSION_ID, requestInfo));
-        
-        verify(sessionUserService, times(1)).findById(SESSION_ID);
-        verify(emailService, times(0)).sendEmailAuthCode(null);
-    }
-    
-    @DisplayName("인증 코드 메일 발송 - 성공")
-    @Test
-    void send_email_auth_code() {
-        // given
-        SessionUser sessionUser = SessionUser.builder()
-                .sessionId(SESSION_ID)
-                .email(EMAIL).build();
-        EmailAuthCodeRequest requestInfo = EmailAuthCodeRequest.of(EMAIL);
-        
-        // when
-        when(sessionUserService.findById(SESSION_ID)).thenReturn(sessionUser);
-        
-        signupService.sendEmailAuthCode(SESSION_ID, requestInfo);
-        
-        // then
-        verify(sessionUserService, times(1)).findById(SESSION_ID);
-        verify(emailService, times(1)).sendEmailAuthCode(requestInfo.getEmail());
-    }
     
 }

--- a/simpleBoard02/server-b-user/src/test/resources/application.yml
+++ b/simpleBoard02/server-b-user/src/test/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  config:
+    import: classpath:password.yml
+
   datasource:
     url: jdbc:h2:./server-b-user/h2/member-test;AUTO_SERVER=true;mode=MYSQL;
     username: sa
@@ -16,6 +19,24 @@ spring:
         show_sql: true
         format_sql: true
         highlight_sql: true
+
+  mail:
+    protocol: smtp
+    host: smtp.gmail.com
+    port: 465
+    username: gimwlgus@gmail.com
+    password: ${email.password.gmail}
+    default-encoding: UTF-8
+    properties:
+      debug: true
+      mail:
+        smtp:
+          auth: true
+          ssl:
+            enable: true
+            trust: smtp.gmail.com
+          starttls:
+            enable: true
 
 logging:
   level:

--- a/simpleBoard02/server-b-user/src/test/resources/application.yml
+++ b/simpleBoard02/server-b-user/src/test/resources/application.yml
@@ -20,6 +20,11 @@ spring:
         format_sql: true
         highlight_sql: true
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
   mail:
     protocol: smtp
     host: smtp.gmail.com

--- a/simpleBoard02/server-b-user/src/test/resources/junit-platform.properties
+++ b/simpleBoard02/server-b-user/src/test/resources/junit-platform.properties
@@ -1,0 +1,2 @@
+# ClassOrderer$OrderAnnotation sorts classes based on their @Order annotation
+junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$OrderAnnotation


### PR DESCRIPTION
## refactor
#### 1. 디렉터리 구조 변경
- /main/entity   -->  /main/data/entity
- /main/data/ResponseMessage.java   -->  /main/data/message/ResponseMessage.java 
- /main/data/type/ExceptionType.java   -->  /main/data/message/ExceptionMessage.java <br><br>

#### 2. **Message.java 타입 변경
- enum  -> class

<br>

## 신규
#### 1. 메일 인증 코드 발송 구현
#### 2. 메일 인증 코드 발송 테스트
#### 3. 메일 인증 코드 검증 구현
#### 4. 메일 인증 코드 검증 테스트

<br>

### 참고 사항
- 테스트시 test container를 사용하여 운영 redis가 아닌 가상의 테스트 redis를 사용하도록 적용
- 테스트 설정파일 `junit-platform.properties`을 추가하여 전체 테스트시 redis repository 테스트가 제일 먼저 실행되도록 적용
- 이메일 인증 완료 후 중복 확인을 실행하면 해당 session은 이메일 인증을 받지 않은 상태가 되도록 구현
- `회원가입 요청이 들어오면` rdb에서 이메일, 닉네임 중복확인을 한번 더 수행하는게 좋을 것 같다.
  - 닉네임은 redis에서 닉네임 예약 저장소를 만들어 관리하지만, email은 rdb에서만 사용중인지 판단하기 때문이다.

<br>

---

<br>

SB2-18